### PR TITLE
feat(web-client): support browser autocomplete for wallet address / PIN

### DIFF
--- a/web-client/src/app/views/lockscreen/lockscreen.page.html
+++ b/web-client/src/app/views/lockscreen/lockscreen.page.html
@@ -15,6 +15,14 @@
         <ion-icon name="lock-closed-outline" class="!text-5xl"></ion-icon>
         <h1 class="font-semibold font-nasalization">Enter Pin</h1>
         <form [formGroup]="codeForm" (ngSubmit)="onSubmit()">
+          <input
+            *ngIf="hiddenAutocompleteUsername !== undefined"
+            type="text"
+            [attr.value]="hiddenAutocompleteUsername"
+            hidden
+            autocomplete="username"
+          />
+
           <ion-input
             type="password"
             formControlName="code"
@@ -24,6 +32,7 @@
             maxlength="10"
             [ngClass]="{'invalid': codeForm.dirty && codeForm.invalid}"
             [inputMask]="numInputMask"
+            autocomplete="current-password"
           ></ion-input>
 
           <ion-button expand="block" shape="round" type="submit"

--- a/web-client/src/app/views/lockscreen/lockscreen.page.ts
+++ b/web-client/src/app/views/lockscreen/lockscreen.page.ts
@@ -16,6 +16,15 @@ export type LockscreenResult = {
 export class LockscreenPage implements OnInit {
   @Input() autofocus = true;
 
+  /**
+   * Optionally render a hidden `autocomplete="username"` input with the given value.
+   *
+   * The browser will associate this value with the entered PIN, if the user chooses to save it.
+   *
+   * @see https://www.chromium.org/developers/design-documents/form-styles-that-chromium-understands
+   */
+  @Input() hiddenAutocompleteUsername?: string;
+
   codeForm: FormGroup;
   numInputMask = createMask({
     alias: 'numeric',

--- a/web-client/src/app/views/register/register.page.html
+++ b/web-client/src/app/views/register/register.page.html
@@ -52,6 +52,9 @@
           formControlName="pin"
           minlength="4"
           maxlength="10"
+          inputmode="numeric"
+          pattern="\d{4,10}"
+          autocomplete="new-password"
           [inputMask]="numInputMask"
         ></ion-input>
         <p
@@ -77,6 +80,9 @@
           formControlName="confirmPin"
           minlength="4"
           maxlength="10"
+          inputmode="numeric"
+          pattern="\d{4,10}"
+          autocomplete="new-password"
           [inputMask]="numInputMask"
         ></ion-input>
         <p

--- a/web-client/src/app/views/register/register.page.html
+++ b/web-client/src/app/views/register/register.page.html
@@ -11,6 +11,7 @@
           type="text"
           formControlName="firstName"
           name="firstName"
+          autocomplete="given-name"
         ></ion-input>
         <p
           *ngIf="(f.firstName.touched && f.firstName.errors?.required) || !nonValidSubmit && f.firstName.errors?.required"
@@ -20,7 +21,11 @@
       </ng-container>
       <ng-container>
         <ion-label position="stacked" for="lastName">Last Name</ion-label>
-        <ion-input type="text" formControlName="lastName"></ion-input>
+        <ion-input
+          type="text"
+          formControlName="lastName"
+          autocomplete="family-name"
+        ></ion-input>
         <p
           *ngIf="(f.lastName.touched && f.lastName.dirty && f.lastName.errors?.required) || !nonValidSubmit && f.lastName.errors?.required"
         >
@@ -32,6 +37,7 @@
         <ion-input
           type="text"
           formControlName="mobile"
+          autocomplete="tel"
           [inputMask]="phoneInputMask"
         ></ion-input>
         <p

--- a/web-client/src/app/views/wallet-access/wallet-access.page.html
+++ b/web-client/src/app/views/wallet-access/wallet-access.page.html
@@ -12,18 +12,24 @@
           </ion-button>
           <p>OR</p>
         </ng-container>
-        <ion-textarea
-          placeholder="Enter wallet address"
-          [(ngModel)]="address"
-        ></ion-textarea>
-        <ion-button
-          [disabled]="!address"
-          expand="block"
-          shape="round"
-          class="mt-4"
-          (click)="confirm(address)"
-          >Confirm</ion-button
-        >
+        <form>
+          <ion-input
+            type="text"
+            name="address"
+            placeholder="Enter wallet address"
+            autocomplete="username"
+            [(ngModel)]="address"
+          ></ion-input>
+          <ion-button
+            type="submit"
+            [disabled]="!address"
+            expand="block"
+            shape="round"
+            class="mt-4"
+            (click)="confirm(address)"
+            >Confirm</ion-button
+          >
+        </form>
       </ion-col>
     </ion-row>
   </ion-grid>

--- a/web-client/src/app/views/wallet-access/wallet-access.page.spec.ts
+++ b/web-client/src/app/views/wallet-access/wallet-access.page.spec.ts
@@ -93,7 +93,7 @@ describe('WalletAccessPage', () => {
     it('returns pin', async () => {
       await withStubbedModal<LockscreenResult>(
         modalCtrl,
-        LockscreenPage,
+        { component: LockscreenPage },
         { success: true, pin: '1234' },
         async () => {
           const { pin } = await component.presentLock();

--- a/web-client/src/app/views/wallet-access/wallet-access.page.spec.ts
+++ b/web-client/src/app/views/wallet-access/wallet-access.page.spec.ts
@@ -91,9 +91,13 @@ describe('WalletAccessPage', () => {
     });
 
     it('returns pin', async () => {
+      component.address = 'wallet address';
       await withStubbedModal<LockscreenResult>(
         modalCtrl,
-        { component: LockscreenPage },
+        {
+          component: LockscreenPage,
+          componentProps: { hiddenAutocompleteUsername: 'wallet address' },
+        },
         { success: true, pin: '1234' },
         async () => {
           const { pin } = await component.presentLock();

--- a/web-client/src/app/views/wallet-access/wallet-access.page.ts
+++ b/web-client/src/app/views/wallet-access/wallet-access.page.ts
@@ -72,7 +72,12 @@ export class WalletAccessPage implements OnInit {
   }
 
   async presentLock(): Promise<LockscreenResult> {
-    const lock = await this.modalCtrl.create({ component: LockscreenPage });
+    const lock = await this.modalCtrl.create({
+      component: LockscreenPage,
+      componentProps: {
+        hiddenAutocompleteUsername: this.address,
+      },
+    });
 
     const dismiss = lock.onDidDismiss();
     await lock.present();

--- a/web-client/src/tests/modal.helpers.spec.ts
+++ b/web-client/src/tests/modal.helpers.spec.ts
@@ -1,5 +1,5 @@
 import { ModalController } from '@ionic/angular';
-import { ComponentRef } from '@ionic/core';
+import { ModalOptions } from '@ionic/core';
 import { ScannerPage, ScanResult } from 'src/app/views/scanner/scanner.page';
 
 export type ModalSpies = {
@@ -23,11 +23,9 @@ export const stubModalResult = <R>(
 /** Expect a modal with the given component to have been presented. */
 export const expectModalComponentPresented = (
   spies: ModalSpies,
-  expectedComponent: ComponentRef
+  expectedCreateOpts: ModalOptions
 ): void => {
-  expect(spies.modalCreateSpy).toHaveBeenCalledOnceWith({
-    component: expectedComponent,
-  });
+  expect(spies.modalCreateSpy).toHaveBeenCalledOnceWith(expectedCreateOpts);
   expect(spies.modalSpy.present).toHaveBeenCalledOnceWith();
 };
 
@@ -36,13 +34,13 @@ export const expectModalComponentPresented = (
  */
 export const withStubbedModal = async <R>(
   modalCtrl: ModalController,
-  expectedComponent: ComponentRef,
+  expectedCreateOpts: ModalOptions,
   dismissResult: R,
   f: () => Promise<void>
 ): Promise<void> => {
   const modalSpies = stubModalResult(modalCtrl, dismissResult);
   await f();
-  expectModalComponentPresented(modalSpies, expectedComponent);
+  expectModalComponentPresented(modalSpies, expectedCreateOpts);
 };
 
 /**
@@ -55,7 +53,7 @@ export const withStubbedModalScanner = async (
 ): Promise<void> => {
   await withStubbedModal<ScanResult>(
     modalCtrl,
-    ScannerPage,
+    { component: ScannerPage },
     dismissResult,
     async () => {
       await f();


### PR DESCRIPTION
This also declares autocomplete for the registration form's name and mobile number fields.

This is mainly to ease repeated sign-ins and registrations while developing, which can get very laborious otherwise.

- Depends on https://github.com/ntls-io/nautilus-wallet/pull/148

On hold until we have the feature flags to conditionally enable this for development.