### PR TITLE
fix(asset-services): update to tower-http 0.1.2 for CORS support

### DIFF
--- a/asset-services/Cargo.lock
+++ b/asset-services/Cargo.lock
@@ -1830,8 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.1.1"
-source = "git+https://github.com/tower-rs/tower-http?branch=cors#9f09fc55bf74b5b9a8bd79cbede7e73d37a3e79b"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f70061b0592867f0a60e67a6e699da5fe000c88a360a5b92ebdba9d73b2238c"
 dependencies = [
  "bytes",
  "futures-core",

--- a/asset-services/Cargo.toml
+++ b/asset-services/Cargo.toml
@@ -7,9 +7,3 @@ members = [
     'onfido',
     'twilio-verify',
 ]
-
-
-[patch.crates-io]
-# XXX(Pi): Upstream PR: Add Cors for setting CORS headers
-#          <https://github.com/tower-rs/tower-http/pull/112>
-tower-http = { git = "https://github.com/tower-rs/tower-http", branch = "cors" }

--- a/asset-services/asset-services-api/Cargo.toml
+++ b/asset-services/asset-services-api/Cargo.toml
@@ -14,7 +14,7 @@ axum = "0.2"
 log = "0.4"
 serde = "1.0"
 tokio = { version = "1", features = ["macros"] }
-tower-http = { version = "0.1", features = ["cors"] }
+tower-http = { version = "0.1.2", features = ["cors"] }
 
 env-var-helpers = { git = "https://github.com/PiDelport/rust-env-var-helpers" }
 


### PR DESCRIPTION
This fixes the build: GitHub's no longer serving the old revision.