### PR TITLE
feat: Dockerfile update Apple Silicon

### DIFF
--- a/web-server/Dockerfile
+++ b/web-server/Dockerfile
@@ -54,7 +54,7 @@ ARG SGX_MODE="SW"
 
 # STAGE: base
 # Common base for both builder and runner stages, with apt caching, ca-certificates, and a non-root user
-FROM ubuntu:20.04 AS base
+FROM --platform=linux/amd64 ubuntu:20.04 AS base 
 
 RUN rm /etc/apt/apt.conf.d/docker-clean
 

--- a/web-server/docker-compose.yaml
+++ b/web-server/docker-compose.yaml
@@ -10,7 +10,7 @@
 
 services:
 
-  server-sw:
+  server- :
     profiles: ["sw"]
     build:
       context: .


### PR DESCRIPTION
Docker images built with Apple Silicon (or another ARM64 based architecture) can create issues when deploying the images to a Linux or Windows-based AMD64 environment. Therefore, you need a way to build AMD64 based images on the ARM64 architecture, whether it's using Docker build (for individual images) or docker-compose build (e.g. for multi-image apps running in a docker-compose network)