### PR TITLE
feat(web-client): balance summary & refresh button

### DIFF
--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.html
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.html
@@ -1,1 +1,26 @@
-<p>balance-summary-card works!</p>
+<ion-card class="app-item ion-text-center">
+  <ion-card-header>
+    <ion-card-title class="font-nasalization">Balances</ion-card-title>
+  </ion-card-header>
+
+  <ion-card-content>
+    <ion-list lines="none">
+      <ion-grid>
+        <ng-container *ngFor="let balance of balances">
+          <ion-row class="ion-align-items-center">
+            <ion-col size="7" class="ion-text-end">
+              <ion-text color="white" class="text-2xl font-audiowide">
+                {{ balance | assetAmount }}
+              </ion-text>
+            </ion-col>
+            <ion-col size="5" class="ion-text-start">
+              <ion-text color="secondary" class="font-bold">
+                {{ balance | assetSymbol }}
+              </ion-text>
+            </ion-col>
+          </ion-row>
+        </ng-container>
+      </ion-grid>
+    </ion-list>
+  </ion-card-content>
+</ion-card>

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.html
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.html
@@ -1,0 +1,1 @@
+<p>balance-summary-card works!</p>

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.spec.ts
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { IonicModule } from '@ionic/angular';
+import { BalanceSummaryCardComponent } from './balance-summary-card.component';
+
+describe('BalanceSummaryCardComponent', () => {
+  let component: BalanceSummaryCardComponent;
+  let fixture: ComponentFixture<BalanceSummaryCardComponent>;
+
+  beforeEach(
+    waitForAsync(() => {
+      TestBed.configureTestingModule({
+        declarations: [BalanceSummaryCardComponent],
+        imports: [IonicModule.forRoot()],
+      }).compileComponents();
+
+      fixture = TestBed.createComponent(BalanceSummaryCardComponent);
+      component = fixture.componentInstance;
+      fixture.detectChanges();
+    })
+  );
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.stories.ts
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.stories.ts
@@ -1,0 +1,17 @@
+import { Story } from '@storybook/angular';
+import { BalanceSummaryCardComponent } from 'src/app/components/balance-summary-card/balance-summary-card.component';
+import { ionicStoryMeta } from 'src/stories/storybook.helpers';
+
+export default ionicStoryMeta<BalanceSummaryCardComponent>({
+  title: 'Components/BalanceSummaryCard',
+  component: BalanceSummaryCardComponent,
+});
+
+const Template: Story<BalanceSummaryCardComponent> = (
+  args: BalanceSummaryCardComponent
+) => ({
+  props: args,
+});
+
+export const Default = Template.bind({});
+Default.args = {};

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.stories.ts
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.stories.ts
@@ -1,11 +1,21 @@
 import { Story } from '@storybook/angular';
-import { BalanceSummaryCardComponent } from 'src/app/components/balance-summary-card/balance-summary-card.component';
+import { algoAmount, xrpAmount } from 'src/app/utils/asset.display';
 import { ionicStoryMeta } from 'src/stories/storybook.helpers';
+import { BalanceSummaryCardComponent } from './balance-summary-card.component';
+import { BalanceSummaryCardComponentModule } from './balance-summary-card.module';
 
-export default ionicStoryMeta<BalanceSummaryCardComponent>({
-  title: 'Components/BalanceSummaryCard',
-  component: BalanceSummaryCardComponent,
-});
+export default ionicStoryMeta<BalanceSummaryCardComponent>(
+  {
+    title: 'Components/BalanceSummaryCard',
+    component: BalanceSummaryCardComponent,
+  },
+  {
+    imports: [BalanceSummaryCardComponentModule],
+    controls: {
+      shown: ['balances'],
+    },
+  }
+);
 
 const Template: Story<BalanceSummaryCardComponent> = (
   args: BalanceSummaryCardComponent
@@ -13,5 +23,10 @@ const Template: Story<BalanceSummaryCardComponent> = (
   props: args,
 });
 
-export const Default = Template.bind({});
-Default.args = {};
+export const Empty = Template.bind({});
+Empty.args = {};
+
+export const WithBalances = Template.bind({});
+WithBalances.args = {
+  balances: [algoAmount(1234.56), xrpAmount(123.456789)],
+};

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.ts
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.ts
@@ -1,4 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
+import { AssetAmount } from 'src/app/utils/asset.display';
 
 @Component({
   selector: 'app-balance-summary-card',
@@ -6,6 +7,8 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./balance-summary-card.component.scss'],
 })
 export class BalanceSummaryCardComponent implements OnInit {
+  @Input() balances?: AssetAmount[] | null;
+
   constructor() {}
 
   ngOnInit() {}

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.ts
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.ts
@@ -1,0 +1,12 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-balance-summary-card',
+  templateUrl: './balance-summary-card.component.html',
+  styleUrls: ['./balance-summary-card.component.scss'],
+})
+export class BalanceSummaryCardComponent implements OnInit {
+  constructor() {}
+
+  ngOnInit() {}
+}

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.module.ts
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.module.ts
@@ -1,11 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { FormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
+import { AssetPipesModule } from 'src/app/pipes/asset-pipes.module';
 import { BalanceSummaryCardComponent } from './balance-summary-card.component';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, IonicModule],
+  imports: [CommonModule, IonicModule, AssetPipesModule],
   declarations: [BalanceSummaryCardComponent],
   exports: [BalanceSummaryCardComponent],
 })

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.module.ts
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.module.ts
@@ -1,0 +1,12 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { IonicModule } from '@ionic/angular';
+import { BalanceSummaryCardComponent } from './balance-summary-card.component';
+
+@NgModule({
+  imports: [CommonModule, FormsModule, IonicModule],
+  declarations: [BalanceSummaryCardComponent],
+  exports: [BalanceSummaryCardComponent],
+})
+export class BalanceSummaryCardComponentModule {}

--- a/web-client/src/app/components/header/header.component.html
+++ b/web-client/src/app/components/header/header.component.html
@@ -3,7 +3,11 @@
     <ion-buttons slot="start">
       <ion-back-button></ion-back-button>
     </ion-buttons>
+
     <ion-title class="font-audiowide font-bold">{{ title }}</ion-title>
+
+    <ng-content></ng-content>
+
     <ion-buttons slot="end" *ngIf="sessionQuery.name | async">
       <ion-button routerLink="/" routerDirection="root"> Logout </ion-button>
     </ion-buttons>

--- a/web-client/src/app/pipes/asset-amount.pipe.spec.ts
+++ b/web-client/src/app/pipes/asset-amount.pipe.spec.ts
@@ -1,0 +1,27 @@
+import { algoAmount, xrpAmount } from 'src/app/utils/asset.display';
+import { AssetAmountPipe } from './asset-amount.pipe';
+
+describe('AssetAmountPipe', () => {
+  let pipe: AssetAmountPipe;
+
+  beforeEach(() => {
+    pipe = new AssetAmountPipe();
+  });
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('formats', () => {
+    expect(pipe.transform(algoAmount(123.456))).toBe('123.456');
+    expect(pipe.transform(xrpAmount(123.456789))).toBe('123.456789');
+  });
+
+  it('skips null', () => {
+    expect(pipe.transform(undefined)).toBe(undefined);
+  });
+
+  it('skips undefined', () => {
+    expect(pipe.transform(undefined)).toBe(undefined);
+  });
+});

--- a/web-client/src/app/pipes/asset-amount.pipe.ts
+++ b/web-client/src/app/pipes/asset-amount.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { AssetAmount, formatAssetAmount } from 'src/app/utils/asset.display';
+
+/** @see formatAssetAmount */
+@Pipe({
+  name: 'assetAmount',
+  pure: true,
+})
+export class AssetAmountPipe implements PipeTransform {
+  transform(assetAmount?: AssetAmount | null): string | null | undefined {
+    return assetAmount ? formatAssetAmount(assetAmount) : assetAmount;
+  }
+}

--- a/web-client/src/app/pipes/asset-pipes.module.ts
+++ b/web-client/src/app/pipes/asset-pipes.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { AssetAmountPipe } from 'src/app/pipes/asset-amount.pipe';
+import { AssetSymbolPipe } from 'src/app/pipes/asset-symbol.pipe';
+
+const declarations = [AssetAmountPipe, AssetSymbolPipe];
+
+@NgModule({
+  imports: [],
+  declarations,
+  exports: declarations,
+})
+export class AssetPipesModule {}

--- a/web-client/src/app/pipes/asset-symbol.pipe.spec.ts
+++ b/web-client/src/app/pipes/asset-symbol.pipe.spec.ts
@@ -1,0 +1,27 @@
+import { algoAmount, xrpAmount } from 'src/app/utils/asset.display';
+import { AssetSymbolPipe } from './asset-symbol.pipe';
+
+describe('AssetSymbolPipe', () => {
+  let pipe: AssetSymbolPipe;
+
+  beforeEach(() => {
+    pipe = new AssetSymbolPipe();
+  });
+
+  it('create an instance', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('formats', () => {
+    expect(pipe.transform(algoAmount(0))).toBe('ALGO');
+    expect(pipe.transform(xrpAmount(0))).toBe('XRP');
+  });
+
+  it('skips null', () => {
+    expect(pipe.transform(undefined)).toBe(undefined);
+  });
+
+  it('skips undefined', () => {
+    expect(pipe.transform(undefined)).toBe(undefined);
+  });
+});

--- a/web-client/src/app/pipes/asset-symbol.pipe.ts
+++ b/web-client/src/app/pipes/asset-symbol.pipe.ts
@@ -1,0 +1,13 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { AssetAmount, formatAssetSymbol } from 'src/app/utils/asset.display';
+
+/** @see formatAssetSymbol */
+@Pipe({
+  name: 'assetSymbol',
+  pure: true,
+})
+export class AssetSymbolPipe implements PipeTransform {
+  transform(assetAmount?: AssetAmount | null): string | null | undefined {
+    return assetAmount ? formatAssetSymbol(assetAmount) : assetAmount;
+  }
+}

--- a/web-client/src/app/utils/asset.display.spec.ts
+++ b/web-client/src/app/utils/asset.display.spec.ts
@@ -1,0 +1,49 @@
+import {
+  algoAmount,
+  AssetAmount,
+  formatAssetAmount,
+  formatAssetSymbol,
+  xrpAmount,
+} from 'src/app/utils/asset.display';
+
+describe('formatAssetSymbol', () => {
+  describe('transforms', () => {
+    const examples: [AssetAmount, string][] = [
+      [algoAmount(0), 'ALGO'],
+      [xrpAmount(0), 'XRP'],
+    ];
+
+    for (const [assetAmount, expected] of examples) {
+      it(`${JSON.stringify(assetAmount)} → ${JSON.stringify(expected)}`, () => {
+        expect(formatAssetSymbol(assetAmount)).toBe(expected);
+      });
+    }
+  });
+});
+
+describe('formatAssetAmount', () => {
+  describe('transforms', () => {
+    const examples: [AssetAmount, string][] = [
+      [algoAmount(-1), '-1'],
+      [algoAmount(0), '0'],
+      [algoAmount(1), '1'],
+      [algoAmount(123.456), '123.456'],
+      [algoAmount(123456.789), '123,456.789'],
+      [algoAmount(1.23456789), '1.234568'], // Rounding
+
+      [xrpAmount(-1), '-1'],
+      [xrpAmount(0), '0'],
+      [xrpAmount(1), '1'],
+      [xrpAmount(123.456), '123.456'],
+      [xrpAmount(123.456789), '123.456789'],
+      [algoAmount(123456.789), '123,456.789'],
+      [xrpAmount(1.23456789), '1.234568'], // Rounding
+    ];
+
+    for (const [assetAmount, expected] of examples) {
+      it(`${JSON.stringify(assetAmount)} → ${JSON.stringify(expected)}`, () => {
+        expect(formatAssetAmount(assetAmount)).toBe(expected);
+      });
+    }
+  });
+});

--- a/web-client/src/app/utils/asset.display.ts
+++ b/web-client/src/app/utils/asset.display.ts
@@ -1,0 +1,57 @@
+/**
+ * Helpers for representing and displaying asset amounts.
+ */
+import { formatNumber } from '@angular/common';
+
+/**
+ * An application-wide description of a particular asset.
+ *
+ * This type is primarily concerned with display concerns.
+ * Assets may be well-known and predefined, or dynamic.
+ */
+export type AssetInfo = {
+  assetSymbol: string;
+  minDigits: number;
+  maxDigits: number;
+};
+
+/** An amount denominated in a particular asset. */
+export type AssetAmount = {
+  amount: number;
+  assetInfo: AssetInfo;
+};
+
+/** Format the asset symbol of an amount. */
+export const formatAssetSymbol = (assetAmount: AssetAmount) =>
+  assetAmount.assetInfo.assetSymbol;
+
+/** Default locale, matching Angular's {@link formatNumber}. */
+const LOCALE = 'en-US';
+
+/** Format an asset amount with the right number of fractional digits. .*/
+export const formatAssetAmount = ({
+  amount,
+  assetInfo: { maxDigits, minDigits },
+}: AssetAmount) => formatNumber(amount, LOCALE, `1.${minDigits}-${maxDigits}`);
+
+export const algoInfo: AssetInfo = {
+  assetSymbol: 'ALGO',
+  minDigits: 0,
+  maxDigits: 6,
+};
+
+export const xrpInfo: AssetInfo = {
+  assetSymbol: 'XRP',
+  minDigits: 0,
+  maxDigits: 6,
+};
+
+export const algoAmount = (amount: number): AssetAmount => ({
+  amount,
+  assetInfo: algoInfo,
+});
+
+export const xrpAmount = (amount: number): AssetAmount => ({
+  amount,
+  assetInfo: xrpInfo,
+});

--- a/web-client/src/app/views/wallet/wallet.module.ts
+++ b/web-client/src/app/views/wallet/wallet.module.ts
@@ -17,5 +17,6 @@ import { WalletPage } from './wallet.page';
     BalanceSummaryCardComponentModule,
   ],
   declarations: [WalletPage],
+  exports: [WalletPage],
 })
 export class WalletPageModule {}

--- a/web-client/src/app/views/wallet/wallet.module.ts
+++ b/web-client/src/app/views/wallet/wallet.module.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
+import { BalanceSummaryCardComponentModule } from 'src/app/components/balance-summary-card/balance-summary-card.module';
 import { SharedModule } from 'src/app/modules/shared/shared.module';
 import { WalletPageRoutingModule } from './wallet-routing.module';
 import { WalletPage } from './wallet.page';
@@ -13,6 +14,7 @@ import { WalletPage } from './wallet.page';
     IonicModule,
     WalletPageRoutingModule,
     SharedModule,
+    BalanceSummaryCardComponentModule,
   ],
   declarations: [WalletPage],
 })

--- a/web-client/src/app/views/wallet/wallet.page.html
+++ b/web-client/src/app/views/wallet/wallet.page.html
@@ -11,6 +11,10 @@
       </h1>
       <p>Send or receive money quickly and easily, select an option below</p>
     </div>
+
+    <app-balance-summary-card [balances]="balances | async">
+    </app-balance-summary-card>
+
     <ion-list>
       <app-action-item
         *ngFor="let item of actionItems"

--- a/web-client/src/app/views/wallet/wallet.page.html
+++ b/web-client/src/app/views/wallet/wallet.page.html
@@ -1,5 +1,9 @@
 <ion-header class="ion-no-border">
-  <app-header></app-header>
+  <app-header>
+    <ion-buttons slot="end">
+      <ion-button (click)="onRefresh()">Refresh</ion-button>
+    </ion-buttons>
+  </app-header>
 </ion-header>
 
 <ion-content>

--- a/web-client/src/app/views/wallet/wallet.page.spec.ts
+++ b/web-client/src/app/views/wallet/wallet.page.spec.ts
@@ -1,15 +1,16 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
 import { routes } from 'src/app/app-routing.module';
-import { SharedModule } from 'src/app/modules/shared/shared.module';
 import { SessionStore } from 'src/app/state/session.store';
 import { stubActiveSession } from 'src/tests/state.helpers';
 import {
   componentElement,
   verifyNavigationTrigger,
 } from 'src/tests/test.helpers';
+import { WalletPageModule } from './wallet.module';
 import { WalletPage } from './wallet.page';
 
 describe('WalletPage', () => {
@@ -23,7 +24,8 @@ describe('WalletPage', () => {
         imports: [
           IonicModule.forRoot(),
           RouterTestingModule.withRoutes(routes),
-          SharedModule,
+          HttpClientTestingModule,
+          WalletPageModule,
         ],
       }).compileComponents();
       router = TestBed.inject(Router);

--- a/web-client/src/app/views/wallet/wallet.page.stories.ts
+++ b/web-client/src/app/views/wallet/wallet.page.stories.ts
@@ -1,10 +1,11 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Story } from '@storybook/angular';
-import { SharedModule } from 'src/app/modules/shared/shared.module';
 import { WalletDisplay } from 'src/schema/entities';
 import {
   ionicStoryMeta,
   provideSessionStore,
 } from 'src/stories/storybook.helpers';
+import { WalletPageModule } from './wallet.module';
 import { WalletPage } from './wallet.page';
 
 export default ionicStoryMeta<WalletDisplay>(
@@ -13,7 +14,7 @@ export default ionicStoryMeta<WalletDisplay>(
     component: WalletPage,
   },
   {
-    imports: [SharedModule],
+    imports: [HttpClientTestingModule, WalletPageModule],
     controls: { shown: ['owner_name'] },
     layoutType: 'page',
   }

--- a/web-client/src/app/views/wallet/wallet.page.ts
+++ b/web-client/src/app/views/wallet/wallet.page.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit } from '@angular/core';
+import { filterNilValue } from '@datorama/akita';
 import {
   faCreditCard,
   faDonate,
@@ -8,7 +9,10 @@ import {
   faReceipt,
   faWallet,
 } from '@fortawesome/free-solid-svg-icons';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { SessionQuery } from 'src/app/state/session.query';
+import { algoAmount, AssetAmount } from 'src/app/utils/asset.display';
 
 @Component({
   selector: 'app-wallet',
@@ -51,6 +55,12 @@ export class WalletPage implements OnInit {
       disabled: true,
     },
   ]; // Placeholder icons until we get definite ones.
+
+  balances: Observable<Array<AssetAmount>> =
+    this.sessionQuery.algorandBalanceInAlgos.pipe(
+      filterNilValue(),
+      map((amount: number): AssetAmount[] => [algoAmount(amount)])
+    );
 
   constructor(public sessionQuery: SessionQuery) {}
 

--- a/web-client/src/app/views/wallet/wallet.page.ts
+++ b/web-client/src/app/views/wallet/wallet.page.ts
@@ -9,10 +9,13 @@ import {
   faReceipt,
   faWallet,
 } from '@fortawesome/free-solid-svg-icons';
+import { LoadingController } from '@ionic/angular';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { SessionAlgorandService } from 'src/app/state/session-algorand.service';
 import { SessionQuery } from 'src/app/state/session.query';
 import { algoAmount, AssetAmount } from 'src/app/utils/asset.display';
+import { withLoadingOverlayOpts } from 'src/app/utils/loading.helpers';
 
 @Component({
   selector: 'app-wallet',
@@ -62,7 +65,21 @@ export class WalletPage implements OnInit {
       map((amount: number): AssetAmount[] => [algoAmount(amount)])
     );
 
-  constructor(public sessionQuery: SessionQuery) {}
+  constructor(
+    private loadingController: LoadingController,
+    public sessionQuery: SessionQuery,
+    public sessionAlgorandService: SessionAlgorandService
+  ) {}
 
   ngOnInit() {}
+
+  async onRefresh(): Promise<void> {
+    await withLoadingOverlayOpts(
+      this.loadingController,
+      { message: 'Refreshing…' },
+      async () => {
+        await this.sessionAlgorandService.loadAccountData();
+      }
+    );
+  }
 }


### PR DESCRIPTION
This adds a basic balance summary and refresh button to the wallet page.

### Related PRs

- Follows https://github.com/ntls-io/nautilus-wallet/pull/167
- Precedes https://github.com/ntls-io/nautilus-wallet/pull/169