### PR TITLE
feat(web-client): support Akita state persistence

### DIFF
--- a/web-client/src/environments/environment.ts
+++ b/web-client/src/environments/environment.ts
@@ -6,6 +6,10 @@ import { Environment } from 'src/environments/types';
 
 export const environment: Environment = {
   production: false,
+
+  // Enable persistence for easier development.
+  persistAkitaState: true,
+
   nautilusWalletServer: 'http://localhost:4200/api/nautilus/',
   nautilusAssetServices: 'http://localhost:4200/api/asset-services/',
   // See `proxyConfig` in `angular.json`, and `proxy.conf.json`

--- a/web-client/src/environments/types.ts
+++ b/web-client/src/environments/types.ts
@@ -13,6 +13,13 @@ export type Environment = {
   production: boolean;
 
   /**
+   * Whether to persist Akita state.
+   *
+   * @see https://datorama.github.io/akita/docs/enhancers/persist-state
+   */
+  persistAkitaState?: boolean;
+
+  /**
    * Base URL for the Nautilus Wallet Enclave.
    * (Must end in "/"!)
    */

--- a/web-client/src/main.ts
+++ b/web-client/src/main.ts
@@ -1,6 +1,6 @@
 import { enableProdMode } from '@angular/core';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
-import { enableAkitaProdMode } from '@datorama/akita';
+import { enableAkitaProdMode, persistState } from '@datorama/akita';
 import { defineCustomElements } from '@ionic/pwa-elements/loader';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
@@ -10,10 +10,9 @@ if (environment.production) {
   enableAkitaProdMode();
 }
 
-// persistState({
-//   enableInNonBrowser: true,
-//   key: 'nautilus',
-// });
+if (environment.persistAkitaState) {
+  persistState({});
+}
 
 platformBrowserDynamic()
   .bootstrapModule(AppModule)


### PR DESCRIPTION
This adds an environment option to enable persistent sessions, which makes development much nicer.

This enables persistence for development by default, but leaves it disabled for production.