### PR TITLE
feat: add enclave XRPL support

### DIFF
--- a/web-client/src/app/services/enclave/enclave.service.spec.ts
+++ b/web-client/src/app/services/enclave/enclave.service.spec.ts
@@ -219,6 +219,11 @@ const placeholderWalletDisplay = (owner_name: string): WalletDisplay => ({
   wallet_id: 'placeholder wallet id',
   owner_name,
   algorand_address_base32: 'placeholder algorand address',
+  xrpl_account: {
+    key_type: 'secp256k1',
+    public_key_hex: 'placeholder public key hex',
+    address_base58: 'placeholder xrp address',
+  },
 });
 
 /**

--- a/web-client/src/app/services/enclave/enclave.service.spec.ts
+++ b/web-client/src/app/services/enclave/enclave.service.spec.ts
@@ -16,6 +16,7 @@ import {
 } from 'src/schema/actions';
 import { AttestationReport } from 'src/schema/attestation';
 import { TweetNaClCrypto } from 'src/schema/crypto';
+import { WalletDisplay } from 'src/schema/entities';
 import { from_msgpack_as, to_msgpack_as } from 'src/schema/msgpack';
 import {
   SealedMessage,
@@ -83,11 +84,7 @@ describe('EnclaveService', () => {
 
     it('Created', async () => {
       const stubResultCreated: CreateWalletResult = {
-        Created: {
-          wallet_id: 'placeholder wallet id',
-          owner_name: requestCreate.owner_name,
-          algorand_address_base32: 'placeholder algorand address',
-        },
+        Created: placeholderWalletDisplay(requestCreate.owner_name),
       };
       const result = await simulateWalletOperation(
         httpTestingController,
@@ -120,11 +117,7 @@ describe('EnclaveService', () => {
 
     it('Opened', async () => {
       const stubResultOpened: OpenWalletResult = {
-        Opened: {
-          wallet_id: 'placeholder wallet id',
-          owner_name: 'placeholder owner name',
-          algorand_address_base32: 'placeholder algorand address',
-        },
+        Opened: placeholderWalletDisplay('placeholder owner name'),
       };
       const result = await simulateWalletOperation(
         httpTestingController,
@@ -220,6 +213,12 @@ describe('EnclaveService', () => {
       await expect(result).toEqual(stubResultFailed);
     });
   });
+});
+
+const placeholderWalletDisplay = (owner_name: string): WalletDisplay => ({
+  wallet_id: 'placeholder wallet id',
+  owner_name,
+  algorand_address_base32: 'placeholder algorand address',
 });
 
 /**

--- a/web-client/src/app/services/enclave/enclave.service.spec.ts
+++ b/web-client/src/app/services/enclave/enclave.service.spec.ts
@@ -84,9 +84,9 @@ describe('EnclaveService', () => {
     it('Created', async () => {
       const stubResultCreated: CreateWalletResult = {
         Created: {
-          wallet_id: 'dummy wallet id',
+          wallet_id: 'placeholder wallet id',
           owner_name: requestCreate.owner_name,
-          algorand_address_base32: 'dummy algorand address',
+          algorand_address_base32: 'placeholder algorand address',
         },
       };
       const result = await simulateWalletOperation(
@@ -114,16 +114,16 @@ describe('EnclaveService', () => {
 
   describe('openWallet', () => {
     const requestOpen: OpenWallet = {
-      wallet_id: 'dummy wallet id',
+      wallet_id: 'placeholder wallet id',
       auth_pin: '1234',
     };
 
     it('Opened', async () => {
       const stubResultOpened: OpenWalletResult = {
         Opened: {
-          wallet_id: 'dummy wallet id',
-          owner_name: 'dummy owner name',
-          algorand_address_base32: 'dummy algorand address',
+          wallet_id: 'placeholder wallet id',
+          owner_name: 'placeholder owner name',
+          algorand_address_base32: 'placeholder algorand address',
         },
       };
       const result = await simulateWalletOperation(
@@ -164,12 +164,12 @@ describe('EnclaveService', () => {
 
   describe('signTransaction', () => {
     const requestSign: SignTransaction = {
-      wallet_id: 'dummy wallet id',
+      wallet_id: 'placeholder wallet id',
       auth_pin: '1234',
       transaction_to_sign: {
         AlgorandTransaction: {
           transaction_bytes: new TextEncoder().encode(
-            'dummy unsigned transaction'
+            'placeholder unsigned transaction'
           ),
         },
       },
@@ -180,7 +180,7 @@ describe('EnclaveService', () => {
         Signed: {
           AlgorandTransactionSigned: {
             signed_transaction_bytes: new TextEncoder().encode(
-              'dummy signed transaction'
+              'placeholder signed transaction'
             ),
           },
         },

--- a/web-client/src/app/state/session.query.spec.ts
+++ b/web-client/src/app/state/session.query.spec.ts
@@ -3,6 +3,7 @@ import {
   convertToAlgos,
   convertToMicroAlgos,
 } from 'src/app/services/algosdk.utils';
+import { WalletDisplay } from 'src/schema/entities';
 import { stubActiveSession } from 'src/tests/state.helpers';
 import { SessionQuery } from './session.query';
 import { SessionState, SessionStore } from './session.store';
@@ -21,10 +22,15 @@ describe('SessionQuery', () => {
   });
 
   const stubState = (): Required<SessionState> => {
-    const wallet = {
+    const wallet: WalletDisplay = {
       wallet_id: 'id',
       owner_name: 'name',
       algorand_address_base32: 'address',
+      xrpl_account: {
+        key_type: 'secp256k1',
+        public_key_hex: 'public key',
+        address_base58: 'address',
+      },
     };
     const state: Required<SessionState> = {
       wallet,
@@ -180,6 +186,11 @@ describe('SessionQuery', () => {
           wallet_id: 'stub',
           owner_name: 'stub',
           algorand_address_base32: 'stub',
+          xrpl_account: {
+            key_type: 'secp256k1',
+            public_key_hex: 'stub',
+            address_base58: 'stub',
+          },
         },
         pin: 'stub',
       });

--- a/web-client/src/app/views/pay/pay.page.stories.ts
+++ b/web-client/src/app/views/pay/pay.page.stories.ts
@@ -42,6 +42,11 @@ const Template: Story<Args> = ({ name, balance, receiverAddress }) => ({
           wallet_id: 'id',
           owner_name: name,
           algorand_address_base32: 'address',
+          xrpl_account: {
+            key_type: 'secp256k1',
+            public_key_hex: 'public key',
+            address_base58: 'address',
+          },
         },
         algorandAccountData: {
           address: 'address',

--- a/web-client/src/app/views/print-wallet/print-wallet.page.spec.ts
+++ b/web-client/src/app/views/print-wallet/print-wallet.page.spec.ts
@@ -49,6 +49,11 @@ describe('PrintWalletPage', () => {
           wallet_id: walletId,
           owner_name: wallet?.owner_name ?? 'fake',
           algorand_address_base32: wallet?.algorand_address_base32 ?? 'fake',
+          xrpl_account: {
+            key_type: wallet?.xrpl_account?.key_type ?? 'secp256k1',
+            public_key_hex: wallet?.xrpl_account?.public_key_hex ?? 'fake',
+            address_base58: wallet?.xrpl_account?.address_base58 ?? 'fake',
+          },
         },
       })
     );

--- a/web-client/src/schema/actions.ts
+++ b/web-client/src/schema/actions.ts
@@ -30,10 +30,12 @@ export type SignTransaction = {
 };
 
 /** For {@link SignTransaction}: A choice of type of transaction to sign. */
-export type TransactionToSign = {
+export type TransactionToSign =
   /** An unsigned Algorand transaction. */
-  AlgorandTransaction: { transaction_bytes: Bytes };
-};
+  | { AlgorandTransaction: { transaction_bytes: Bytes } }
+
+  /** An unsigned XRPL transaction. */
+  | { XrplTransaction: { transaction_bytes: Bytes } };
 
 export type SignTransactionResult =
   | { Signed: TransactionSigned }
@@ -41,10 +43,17 @@ export type SignTransactionResult =
   | { Failed: string };
 
 /** For {@link SignTransactionResult}: The possible types of signed transactions. */
-export type TransactionSigned = {
+export type TransactionSigned =
   /** A signed Algorand transaction. */
-  AlgorandTransactionSigned: { signed_transaction_bytes: Bytes };
-};
+  | { AlgorandTransactionSigned: { signed_transaction_bytes: Bytes } }
+
+  /** A signed Algorand transaction.*/
+  | {
+      XrplTransactionSigned: {
+        signed_transaction_bytes: Bytes;
+        signature_bytes: Bytes;
+      };
+    };
 
 /** Dispatching enum for action requests. */
 export type WalletRequest =

--- a/web-client/src/schema/entities.ts
+++ b/web-client/src/schema/entities.ts
@@ -4,6 +4,9 @@ import {
   AlgorandAccountSeedBytes,
   AlgorandAddressBase32,
   WalletId,
+  XrplAddressBase58,
+  XrplKeyType,
+  XrplPublicKeyHex,
 } from './types';
 
 /** A Nautilus wallet's basic displayable details. */
@@ -11,9 +14,21 @@ export type WalletDisplay = {
   wallet_id: WalletId;
   owner_name: string;
   algorand_address_base32: AlgorandAddressBase32;
+  xrpl_account: XrplAccountDisplay;
 };
+
+// Algorand entities:
 
 /** An Algorand account. */
 export type AlgorandAccount = {
   seed_bytes: AlgorandAccountSeedBytes;
+};
+
+// XRPL entities:
+
+/** An XRP account's displayable details. */
+export type XrplAccountDisplay = {
+  key_type: XrplKeyType;
+  public_key_hex: XrplPublicKeyHex;
+  address_base58: XrplAddressBase58;
 };

--- a/web-client/src/schema/types.ts
+++ b/web-client/src/schema/types.ts
@@ -6,6 +6,7 @@ export type Bytes = Uint8Array;
 // XXX: See: Add Length Parameter to typed arrays #18471 https://github.com/microsoft/TypeScript/issues/18471
 export type Bytes32 = Bytes;
 export type Bytes24 = Bytes;
+export type Bytes16 = Bytes;
 
 /** Nautilus Wallet ID. */
 export type WalletId = string;
@@ -21,3 +22,29 @@ export type AlgorandAddressBytes = Bytes32;
 
 /** Algorand account address, as base32 with checksum. */
 export type AlgorandAddressBase32 = string;
+
+/**
+ * XRP key type (signing algorithm).
+ *
+ * Docs: <https://xrpl.org/cryptographic-keys.html#signing-algorithms>
+ */
+export type XrplKeyType = 'secp256k1' | 'ed25519';
+
+/**
+ *  XRP account seed, as bytes.
+ */
+export type XrpAccountSeedBytes = Bytes16;
+
+/**
+ *  XRP account address, as base58 with checksum ("Base58Check").
+ *
+ *  Docs: <https://xrpl.org/base58-encodings.html>
+ */
+export type XrplAddressBase58 = string;
+
+/**
+ *  XRP public key, as a hexadecimal string. Used to prepare unsigned transactions.
+ *
+ *  Docs: <https://xrpl.org/cryptographic-keys.html#public-key>
+ */
+export type XrplPublicKeyHex = string;

--- a/web-client/src/tests/state.helpers.spec.ts
+++ b/web-client/src/tests/state.helpers.spec.ts
@@ -24,6 +24,11 @@ describe('stubActiveSession', () => {
         wallet_id: 'stub',
         owner_name: 'stub',
         algorand_address_base32: 'stub',
+        xrpl_account: {
+          key_type: 'secp256k1',
+          public_key_hex: 'stub',
+          address_base58: 'stub',
+        },
       },
       pin: 'stub',
     });
@@ -34,6 +39,11 @@ describe('stubActiveSession', () => {
       wallet_id: 'id',
       owner_name: 'name',
       algorand_address_base32: 'address',
+      xrpl_account: {
+        key_type: 'ed25519',
+        public_key_hex: 'public key',
+        address_base58: 'address',
+      },
     };
     const pin = 'secret';
     stubActiveSession(store, { wallet, pin });

--- a/web-client/src/tests/state.helpers.ts
+++ b/web-client/src/tests/state.helpers.ts
@@ -15,6 +15,11 @@ export const stubActiveSession = (
       wallet_id: state?.wallet?.wallet_id ?? 'stub',
       owner_name: state?.wallet?.owner_name ?? 'stub',
       algorand_address_base32: state?.wallet?.algorand_address_base32 ?? 'stub',
+      xrpl_account: {
+        key_type: state?.wallet?.xrpl_account?.key_type ?? 'secp256k1',
+        public_key_hex: state?.wallet?.xrpl_account?.public_key_hex ?? 'stub',
+        address_base58: state?.wallet?.xrpl_account?.address_base58 ?? 'stub',
+      },
     },
     pin: state?.pin ?? 'stub',
   });

--- a/web-server/sgx-wallet-impl/Cargo.lock
+++ b/web-server/sgx-wallet-impl/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "sgx_tstd",
- "sha2",
+ "sha2 0.9.5",
  "static_assertions",
  "thiserror",
 ]
@@ -43,7 +43,7 @@ dependencies = [
  "ring",
  "serde",
  "sgx_tstd",
- "sha2",
+ "sha2 0.9.5",
  "static_assertions",
  "thiserror",
 ]
@@ -76,10 +76,16 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sgx_tstd",
- "sha2",
+ "sha2 0.9.5",
  "thiserror",
  "url",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "autocfg"
@@ -94,6 +100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,11 +113,30 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.4"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -113,6 +144,11 @@ name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
 
 [[package]]
 name = "byteorder"
@@ -156,6 +192,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
+dependencies = [
+ "generic-array 0.12.4",
+ "subtle",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,11 +227,35 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
+dependencies = [
+ "generic-array 0.12.4",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -233,6 +308,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.7.1"
+source = "git+https://github.com/mesalock-linux/rustcrypto-MACs-sgx#e8e1410b9c82d2e59da42fa8b0d8ed38e80a203c"
+dependencies = [
+ "crypto-mac",
+ "digest 0.8.1",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.1.2"
+source = "git+https://github.com/mesalock-linux/hmac-drbg-rs-sgx#89d6b0113157599417af867a8d2b4afd5c6f1946"
+dependencies = [
+ "generic-array 0.12.4",
+ "hmac",
+]
 
 [[package]]
 name = "idna"
@@ -294,6 +387,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
+name = "libsecp256k1"
+version = "0.3.5"
+source = "git+https://github.com/ntls-io/libsecp256k1-rs-sgx#2a6c35a1876b3553486d34142155b89eaae77965"
+dependencies = [
+ "arrayref",
+ "crunchy",
+ "digest 0.8.1",
+ "hmac-drbg",
+ "rand",
+ "sgx_tstd",
+ "sha2 0.8.0",
+ "subtle",
+ "typenum",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +417,27 @@ version = "0.1.8"
 source = "git+https://github.com/mesalock-linux/rust-std-candidates-sgx#5747bcf37f3e18687758838da0339ff0f2c83924"
 
 [[package]]
+name = "num-bigint"
+version = "0.2.5"
+source = "git+https://github.com/mesalock-linux/num-bigint-sgx#76a5bed94dc31c32bd1670dbf72877abcf9bbc09"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.41"
+source = "git+https://github.com/mesalock-linux/num-integer-sgx#404c50e5378ca635261688b080dee328ff42b6bd"
+dependencies = [
+ "autocfg 0.1.7",
+ "num-traits",
+ "sgx_tstd",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.10"
 source = "git+https://github.com/mesalock-linux/num-traits-sgx#af046e0b15c594c960007418097dd4ff37ec3f7a"
@@ -315,6 +445,12 @@ dependencies = [
  "autocfg 0.1.7",
  "sgx_tstd",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -398,6 +534,42 @@ dependencies = [
  "sgx_tstd",
  "spin",
  "untrusted",
+]
+
+[[package]]
+name = "ripemd160"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "ripple-address-codec"
+version = "0.1.1"
+source = "git+https://github.com/ntls-io/ripple-address-codec-rust-sgx?branch=v0.1.1-sgx#e2b03486a9e0627bbc922681863b4661be8a4e3b"
+dependencies = [
+ "base-x",
+ "ring",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "ripple-keypairs"
+version = "0.1.0"
+source = "git+https://github.com/ntls-io/ripple-keypairs-rust-sgx?branch=v0.1.0-sgx#ef55261e2f0aa6b5c54cac43abc4c57b4f97b286"
+dependencies = [
+ "base-x",
+ "hex",
+ "libsecp256k1",
+ "num-bigint",
+ "ring",
+ "ripemd160",
+ "ripple-address-codec",
+ "sgx_tstd",
 ]
 
 [[package]]
@@ -510,6 +682,8 @@ dependencies = [
  "base64",
  "hex",
  "rand",
+ "ripple-address-codec",
+ "ripple-keypairs",
  "rmp-serde",
  "secrecy",
  "serde",
@@ -622,15 +796,27 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.8.0"
+source = "git+https://github.com/mesalock-linux/rustcrypto-hashes-sgx#54ac4af765ec6b424add4e7559e82328bd052060"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "sha2"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
- "opaque-debug",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -661,6 +847,14 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.2.2"
+source = "git+https://github.com/mesalock-linux/subtle-sgx#8ee32fc0902a4594bd12e272357e2d76cde9dad1"
+dependencies = [
+ "sgx_tstd",
+]
 
 [[package]]
 name = "syn"

--- a/web-server/sgx-wallet-impl/Cargo.toml
+++ b/web-server/sgx-wallet-impl/Cargo.toml
@@ -34,6 +34,8 @@ thiserror = { git = "https://github.com/mesalock-linux/thiserror-sgx" }
 # Our SGX forks
 algonaut = { git = "https://github.com/registreerocks/algonaut-sgx", branch = "main-sgx" }
 serde_bytes = { version = "0.11.4", git = "https://github.com/registreerocks/serde-bytes-sgx" } # SGX: registreerocks fork for 0.11.4
+ripple-keypairs = { git = "https://github.com/ntls-io/ripple-keypairs-rust-sgx", branch = "v0.1.0-sgx" }
+ripple-address-codec = { git = "https://github.com/ntls-io/ripple-address-codec-rust-sgx", branch = "v0.1.1-sgx" }
 
 [patch.'https://github.com/apache/teaclave-sgx-sdk.git']
 sgx_libc = { git = "https://github.com/apache/incubator-teaclave-sgx-sdk", rev = "e8a9fc22939befa27ff67f5509b2c2dfe8499945" }

--- a/web-server/sgx-wallet-impl/src/schema/actions.rs
+++ b/web-server/sgx-wallet-impl/src/schema/actions.rs
@@ -63,6 +63,12 @@ pub enum TransactionToSign {
         #[serde(with = "serde_bytes")]
         transaction_bytes: Bytes,
     },
+
+    /// An unsigned XRPL transaction.
+    XrplTransaction {
+        #[serde(with = "serde_bytes")]
+        transaction_bytes: Bytes,
+    },
 }
 
 #[derive(Clone, Eq, PartialEq, Debug)] // core
@@ -95,6 +101,15 @@ pub enum TransactionSigned {
         #[serde(with = "serde_bytes")]
         signed_transaction_bytes: Bytes,
     },
+
+    /// A signed XRPL transaction.
+    XrplTransactionSigned {
+        #[serde(with = "serde_bytes")]
+        signed_transaction_bytes: Bytes,
+
+        #[serde(with = "serde_bytes")]
+        signature_bytes: Bytes,
+    },
 }
 
 impl TransactionSigned {
@@ -111,6 +126,10 @@ impl TransactionSigned {
             TransactionSigned::AlgorandTransactionSigned {
                 signed_transaction_bytes,
             } => signed_transaction_bytes,
+            otherwise => panic!(
+                "called `TransactionSigned::unwrap_algorand_bytes` on: {:?}",
+                otherwise
+            ),
         }
     }
 }

--- a/web-server/sgx-wallet-impl/src/schema/entities.rs
+++ b/web-server/sgx-wallet-impl/src/schema/entities.rs
@@ -12,6 +12,7 @@ use crate::schema::types::{
     AlgorandAddressBytes,
     WalletId,
     WalletPin,
+    XRPAddressBase32,
 };
 
 /// A Nautilus wallet's basic displayable details.
@@ -23,6 +24,7 @@ pub struct WalletDisplay {
     pub wallet_id: WalletId,
     pub owner_name: String,
     pub algorand_address_base32: AlgorandAddressBase32,
+    pub xrp_address_base32: XRPAddressBase32,
 }
 
 impl From<WalletStorable> for WalletDisplay {
@@ -31,6 +33,7 @@ impl From<WalletStorable> for WalletDisplay {
             wallet_id: storable.wallet_id.clone(),
             owner_name: storable.owner_name.clone(),
             algorand_address_base32: storable.algorand_account.address_base32(),
+            xrp_address_base32: storable.xrp_address_base32.address_base32(),
         }
     }
 }

--- a/web-server/sgx-wallet-impl/src/schema/entities.rs
+++ b/web-server/sgx-wallet-impl/src/schema/entities.rs
@@ -1,9 +1,9 @@
 //! Structures representing various entities.
 
-use std::prelude::v1::{String, ToString};
+use std::prelude::v1::{String, ToOwned, ToString};
 
 use algonaut::transaction::account::Account as AlgonautAccount;
-use ripple_keypairs::Seed;
+use ripple_keypairs::{Entropy, EntropyArray, PrivateKey, PublicKey, Seed};
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -13,8 +13,9 @@ use crate::schema::types::{
     AlgorandAddressBytes,
     WalletId,
     WalletPin,
-    XrpAccountSeedBytes,
-    XrpAddressClassic,
+    XrplAddressBase58,
+    XrplKeyType,
+    XrplPublicKeyHex,
 };
 
 /// A Nautilus wallet's basic displayable details.
@@ -25,8 +26,11 @@ use crate::schema::types::{
 pub struct WalletDisplay {
     pub wallet_id: WalletId,
     pub owner_name: String,
+
+    // TODO(Pi): Decouple for multiple accounts per wallet.
     pub algorand_address_base32: AlgorandAddressBase32,
-    pub xrp_address_classic: XrpAddressClassic,
+
+    pub xrpl_account: XrplAccountDisplay,
 }
 
 impl From<WalletStorable> for WalletDisplay {
@@ -35,7 +39,7 @@ impl From<WalletStorable> for WalletDisplay {
             wallet_id: storable.wallet_id.clone(),
             owner_name: storable.owner_name.clone(),
             algorand_address_base32: storable.algorand_account.address_base32(),
-            xrp_address_classic: storable.xrpl_account.address_classic(),
+            xrpl_account: storable.xrpl_account.clone().into(),
         }
     }
 }
@@ -54,20 +58,14 @@ pub struct WalletStorable {
     pub xrpl_account: XrplAccount,
 }
 
+// Algorand entities:
+
 /// An Algorand account.
 #[derive(Clone, Eq, PartialEq, Debug)] // core
 #[derive(Deserialize, Serialize)] // serde
 #[derive(Zeroize, ZeroizeOnDrop)] // zeroize
 pub struct AlgorandAccount {
     pub seed_bytes: AlgorandAccountSeedBytes,
-}
-
-/// An XRPL account.
-#[derive(Clone, Eq, PartialEq, Debug)] // core
-#[derive(Deserialize, Serialize)] // serde
-#[derive(Zeroize, ZeroizeOnDrop)] // zeroize
-pub struct XrplAccount {
-    pub seed_bytes: XrpAccountSeedBytes,
 }
 
 impl AlgorandAccount {
@@ -98,15 +96,101 @@ impl From<AlgorandAccount> for AlgonautAccount {
     }
 }
 
-impl XrplAccount {
-    pub(crate) fn generate() -> Self {
+// XRPL entities:
+
+/// An XRPL account's displayable details.
+#[derive(Clone, Eq, PartialEq, Debug)] // core
+#[derive(Deserialize, Serialize)] // serde
+pub struct XrplAccountDisplay {
+    pub key_type: XrplKeyType,
+    pub public_key_hex: XrplPublicKeyHex,
+    pub address_base58: XrplAddressBase58,
+}
+
+impl From<XrplAccount> for XrplAccountDisplay {
+    fn from(xrpl_account: XrplAccount) -> Self {
         Self {
-            seed_bytes: Seed::random(),
+            key_type: xrpl_account.key_type,
+            public_key_hex: xrpl_account.to_public_key_hex(),
+            address_base58: xrpl_account.to_address_base58(),
+        }
+    }
+}
+
+/// An XRPL account.
+#[derive(Clone, Eq, PartialEq, Debug)] // core
+#[derive(Deserialize, Serialize)] // serde
+#[derive(Zeroize, ZeroizeOnDrop)] // zeroize
+pub struct XrplAccount {
+    #[zeroize(skip)]
+    pub key_type: XrplKeyType,
+
+    pub seed_bytes: EntropyArray,
+}
+
+impl From<Seed> for XrplAccount {
+    fn from(seed: Seed) -> Self {
+        let key_type = seed.as_kind().into();
+        let seed_bytes = seed.as_entropy().to_owned();
+        Self::new(key_type, seed_bytes)
+    }
+}
+
+impl From<XrplAccount> for Seed {
+    fn from(xrpl_account: XrplAccount) -> Self {
+        let entropy = Entropy::Array(xrpl_account.seed_bytes);
+        let kind = xrpl_account.key_type.into();
+        Seed::new(entropy, kind)
+    }
+}
+
+impl XrplAccount {
+    pub(crate) fn new(key_type: XrplKeyType, seed_bytes: EntropyArray) -> Self {
+        Self {
+            key_type,
+            seed_bytes,
         }
     }
 
-    pub fn address_classic(&self) -> XrpAddressClassic {
-        let (_, public_key) = self.seed_bytes.derive_keypair().unwrap();
-        public_key.derive_address()
+    /// Generate a new keypair of the given type.
+    pub(crate) fn generate_default() -> Self {
+        Self::generate(XrplKeyType::default())
+    }
+
+    /// Generate a new keypair of the given type.
+    pub(crate) fn generate(key_type: XrplKeyType) -> Self {
+        Seed::new(Entropy::Random, key_type.into()).into()
+    }
+
+    pub(crate) fn to_seed(&self) -> Seed {
+        self.clone().into()
+    }
+
+    pub(crate) fn to_keypair(&self) -> (PrivateKey, PublicKey) {
+        // XXX(Pi): Performance: Repeated key derivation?
+        self.to_seed()
+            .derive_keypair()
+            // Safety: This should not fail unless something is seriously wrong: treat as unrecoverable.
+            .expect("XrpAccount: derive_keypair failed!")
+    }
+
+    pub(crate) fn to_private_key(&self) -> PrivateKey {
+        let (private_key, _) = self.to_keypair();
+        private_key
+    }
+
+    pub(crate) fn to_public_key(&self) -> PublicKey {
+        let (_, public_key) = self.to_keypair();
+        public_key
+    }
+
+    pub fn to_address_base58(&self) -> XrplAddressBase58 {
+        self.to_public_key().derive_address()
+    }
+
+    // TODO: Support X-Address format? Docs: <https://xrpaddress.info/>
+
+    pub fn to_public_key_hex(&self) -> XrplPublicKeyHex {
+        self.to_public_key().to_string()
     }
 }

--- a/web-server/sgx-wallet-impl/src/schema/types.rs
+++ b/web-server/sgx-wallet-impl/src/schema/types.rs
@@ -3,7 +3,8 @@
 use std::boxed::Box;
 use std::prelude::v1::String;
 
-use ripple_keypairs::Seed;
+use ripple_keypairs::{Algorithm, EntropyArray};
+use serde::{Deserialize, Serialize};
 
 pub type Bytes = Box<[u8]>;
 
@@ -22,8 +23,55 @@ pub type AlgorandAddressBytes = [u8; 32];
 /// Algorand account address, as base32 with checksum.
 pub type AlgorandAddressBase32 = String;
 
-/// XRP account address
-pub type XrpAddressClassic = String;
+/// XRPL key type (signing algorithm).
+///
+/// Docs: <https://xrpl.org/cryptographic-keys.html#signing-algorithms>
+#[derive(Copy, Clone, Eq, PartialEq, Debug)] // core
+#[derive(Deserialize, Serialize)] // serde
+#[serde(rename_all = "lowercase")]
+pub enum XrplKeyType {
+    Secp256k1,
+    Ed25519,
+}
 
-/// Xrp account seed,as bytes
-pub type XrpAccountSeedBytes = Seed;
+/// Default to `secp256k1`, like the XRP Ledger.
+impl Default for XrplKeyType {
+    fn default() -> Self {
+        Self::Secp256k1
+    }
+}
+
+// Convert between our representation and ripple-keypairs.
+
+/// Convert from `&Algorithm`, as used by ripple-keypairs.
+impl From<&Algorithm> for XrplKeyType {
+    fn from(algorithm: &Algorithm) -> Self {
+        match algorithm {
+            Algorithm::Secp256k1 => Self::Secp256k1,
+            Algorithm::Ed25519 => Self::Ed25519,
+        }
+    }
+}
+
+/// Convert to `&'static Algorithm`, as expected by ripple-keypairs.
+impl From<XrplKeyType> for &'static Algorithm {
+    fn from(key_type: XrplKeyType) -> Self {
+        match key_type {
+            XrplKeyType::Secp256k1 => &Algorithm::Secp256k1,
+            XrplKeyType::Ed25519 => &Algorithm::Ed25519,
+        }
+    }
+}
+
+/// XRP account seed, as bytes.
+pub type XrplAccountSeedBytes = EntropyArray;
+
+/// XRP account address, as base58 with checksum ("Base58Check").
+///
+/// Docs: <https://xrpl.org/base58-encodings.html>
+pub type XrplAddressBase58 = String;
+
+/// XRP public key, as a hexadecimal string. Used to prepare unsigned transactions.
+///
+/// Docs: <https://xrpl.org/cryptographic-keys.html#public-key>
+pub type XrplPublicKeyHex = String;

--- a/web-server/sgx-wallet-impl/src/schema/types.rs
+++ b/web-server/sgx-wallet-impl/src/schema/types.rs
@@ -19,3 +19,6 @@ pub type AlgorandAddressBytes = [u8; 32];
 
 /// Algorand account address, as base32 with checksum.
 pub type AlgorandAddressBase32 = String;
+
+/// XRP account address
+pub type XRPAddressBase32 = String;

--- a/web-server/sgx-wallet-impl/src/schema/types.rs
+++ b/web-server/sgx-wallet-impl/src/schema/types.rs
@@ -3,6 +3,8 @@
 use std::boxed::Box;
 use std::prelude::v1::String;
 
+use ripple_keypairs::Seed;
+
 pub type Bytes = Box<[u8]>;
 
 /// Nautilus Wallet ID.
@@ -21,4 +23,7 @@ pub type AlgorandAddressBytes = [u8; 32];
 pub type AlgorandAddressBase32 = String;
 
 /// XRP account address
-pub type XRPAddressBase32 = String;
+pub type XrpAddressClassic = String;
+
+/// Xrp account seed,as bytes
+pub type XrpAccountSeedBytes = Seed;

--- a/web-server/sgx-wallet-impl/src/wallet_operations/create_wallet.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/create_wallet.rs
@@ -7,13 +7,16 @@ use crate::wallet_operations::store::save_new_wallet;
 type Result = CreateWalletResult;
 
 pub fn create_wallet(request: &CreateWallet) -> Result {
-    let new_account = AlgorandAccount::generate();
-    let new_xrpl_account = XrplAccount::generate();
+    // TODO(Pi): Pull account / keypair creation into a separate operation.
+    //           For now, just generate both Algorand and XRP keypairs.
+    let new_algorand_account = AlgorandAccount::generate();
+    let new_xrpl_account = XrplAccount::generate_default();
+
     let storable = WalletStorable {
-        wallet_id: new_account.address_base32(),
+        wallet_id: new_algorand_account.address_base32(),
         owner_name: request.owner_name.clone(),
         auth_pin: request.auth_pin.clone(),
-        algorand_account: new_account,
+        algorand_account: new_algorand_account,
         xrpl_account: new_xrpl_account,
     };
     match save_new_wallet(&storable) {

--- a/web-server/sgx-wallet-impl/src/wallet_operations/create_wallet.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/create_wallet.rs
@@ -13,7 +13,7 @@ pub fn create_wallet(request: &CreateWallet) -> Result {
     let new_xrpl_account = XrplAccount::generate_default();
 
     let storable = WalletStorable {
-        wallet_id: new_algorand_account.address_base32(),
+        wallet_id: new_xrpl_account.to_address_base58(),
         owner_name: request.owner_name.clone(),
         auth_pin: request.auth_pin.clone(),
         algorand_account: new_algorand_account,

--- a/web-server/sgx-wallet-impl/src/wallet_operations/create_wallet.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/create_wallet.rs
@@ -1,18 +1,20 @@
 use std::prelude::v1::ToString;
 
 use crate::schema::actions::{CreateWallet, CreateWalletResult};
-use crate::schema::entities::{AlgorandAccount, WalletDisplay, WalletStorable};
+use crate::schema::entities::{AlgorandAccount, WalletDisplay, WalletStorable, XrplAccount};
 use crate::wallet_operations::store::save_new_wallet;
 
 type Result = CreateWalletResult;
 
 pub fn create_wallet(request: &CreateWallet) -> Result {
     let new_account = AlgorandAccount::generate();
+    let new_xrpl_account = XrplAccount::generate();
     let storable = WalletStorable {
         wallet_id: new_account.address_base32(),
         owner_name: request.owner_name.clone(),
         auth_pin: request.auth_pin.clone(),
         algorand_account: new_account,
+        xrpl_account: new_xrpl_account,
     };
     match save_new_wallet(&storable) {
         Ok(()) => Result::Created(WalletDisplay::from(storable)),

--- a/web-server/sgx-wallet-impl/src/wallet_operations/mod.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/mod.rs
@@ -6,4 +6,5 @@ pub(crate) mod errors;
 pub mod open_wallet;
 pub mod sign_transaction;
 pub mod sign_transaction_algorand;
+pub(crate) mod sign_transaction_xrpl;
 pub mod store;

--- a/web-server/sgx-wallet-impl/src/wallet_operations/sign_transaction.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/sign_transaction.rs
@@ -9,6 +9,7 @@ use crate::schema::actions::{
     TransactionToSign,
 };
 use crate::wallet_operations::sign_transaction_algorand::sign_algorand;
+use crate::wallet_operations::sign_transaction_xrpl::sign_xrpl;
 use crate::wallet_operations::store::load_wallet;
 
 pub fn sign_transaction(request: &SignTransaction) -> SignTransactionResult {
@@ -33,6 +34,14 @@ pub fn sign_transaction(request: &SignTransaction) -> SignTransactionResult {
         TransactionToSign::AlgorandTransaction { transaction_bytes } => {
             sign_algorand(&stored.algorand_account, transaction_bytes)
                 .map(TransactionSigned::from_algorand_bytes)
+        }
+
+        TransactionToSign::XrplTransaction { transaction_bytes } => {
+            let signature_bytes = sign_xrpl(&stored.xrpl_account, transaction_bytes);
+            Ok(TransactionSigned::XrplTransactionSigned {
+                signed_transaction_bytes: transaction_bytes.clone(),
+                signature_bytes,
+            })
         }
     };
 

--- a/web-server/sgx-wallet-impl/src/wallet_operations/sign_transaction_xrpl.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/sign_transaction_xrpl.rs
@@ -1,0 +1,8 @@
+use crate::schema::entities::XrplAccount;
+use crate::schema::types::Bytes;
+
+pub(crate) fn sign_xrpl(signing_account: &XrplAccount, transaction_bytes: &Bytes) -> Bytes {
+    let signature = signing_account.to_private_key().sign(transaction_bytes);
+    let signature_bytes = Bytes::from(signature.as_ref());
+    signature_bytes
+}

--- a/web-server/sgx-wallet-impl/src/wallet_operations/store.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/store.rs
@@ -1,8 +1,5 @@
 use std::io;
 use std::prelude::v1::Box;
-use std::str::FromStr;
-
-use algonaut::core::Address as AlgonautAddress;
 
 use crate::ported::kv_store::fs::{FsStore, SgxFiler};
 use crate::ported::kv_store::{Key, KvStore};
@@ -36,8 +33,8 @@ pub fn load_wallet(wallet_id: &str) -> Result<Option<WalletStorable>, io::Error>
 }
 
 pub fn key_from_id(wallet_id: &str) -> Result<Box<Key>, io::Error> {
-    // XXX: Assume Algorand address, for now.
-    let address = AlgonautAddress::from_str(wallet_id).map_err(|err| {
+    // XXX: Assume XRP address, for now.
+    let address = ripple_address_codec::decode_account_id(wallet_id).map_err(|err| {
         io::Error::new(
             io::ErrorKind::InvalidInput,
             format!(
@@ -46,5 +43,5 @@ pub fn key_from_id(wallet_id: &str) -> Result<Box<Key>, io::Error> {
             ),
         )
     })?;
-    Ok(address.0.into())
+    Ok(address.into())
 }

--- a/web-server/sgx-wallet-test/enclave/Cargo.lock
+++ b/web-server/sgx-wallet-test/enclave/Cargo.lock
@@ -824,6 +824,7 @@ dependencies = [
  "rmp-serde",
  "secrecy",
  "serde",
+ "serde_json",
  "sgx-wallet-impl",
  "sgx_rand",
  "sgx_tcrypto",

--- a/web-server/sgx-wallet-test/enclave/Cargo.lock
+++ b/web-server/sgx-wallet-test/enclave/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "sgx_tstd",
- "sha2",
+ "sha2 0.9.5",
  "static_assertions",
  "thiserror",
 ]
@@ -43,7 +43,7 @@ dependencies = [
  "ring",
  "serde",
  "sgx_tstd",
- "sha2",
+ "sha2 0.9.5",
  "static_assertions",
  "thiserror",
 ]
@@ -76,10 +76,16 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sgx_tstd",
- "sha2",
+ "sha2 0.9.5",
  "thiserror",
  "url",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "autocfg"
@@ -92,6 +98,12 @@ name = "autocfg"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+
+[[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
@@ -113,11 +125,30 @@ checksum = "2da1976d75adbe5fbc88130ecd119529cf1cc6a93ae1546d8696ee66f0d21af1"
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder 1.3.4",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.4"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -125,6 +156,11 @@ name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
 
 [[package]]
 name = "byteorder"
@@ -174,6 +210,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
+dependencies = [
+ "generic-array 0.12.4",
+ "subtle",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,11 +245,35 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
+dependencies = [
+ "generic-array 0.12.4",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -251,6 +326,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.7.1"
+source = "git+https://github.com/mesalock-linux/rustcrypto-MACs-sgx#e8e1410b9c82d2e59da42fa8b0d8ed38e80a203c"
+dependencies = [
+ "crypto-mac",
+ "digest 0.8.1",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.1.2"
+source = "git+https://github.com/mesalock-linux/hmac-drbg-rs-sgx#89d6b0113157599417af867a8d2b4afd5c6f1946"
+dependencies = [
+ "generic-array 0.12.4",
+ "hmac",
+]
 
 [[package]]
 name = "idna"
@@ -312,6 +405,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
+name = "libsecp256k1"
+version = "0.3.5"
+source = "git+https://github.com/ntls-io/libsecp256k1-rs-sgx#2a6c35a1876b3553486d34142155b89eaae77965"
+dependencies = [
+ "arrayref",
+ "crunchy",
+ "digest 0.8.1",
+ "hmac-drbg",
+ "rand 0.7.3",
+ "sgx_tstd",
+ "sha2 0.8.0",
+ "subtle",
+ "typenum",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,6 +433,27 @@ dependencies = [
 name = "matches"
 version = "0.1.8"
 source = "git+https://github.com/mesalock-linux/rust-std-candidates-sgx#5747bcf37f3e18687758838da0339ff0f2c83924"
+
+[[package]]
+name = "num-bigint"
+version = "0.2.5"
+source = "git+https://github.com/mesalock-linux/num-bigint-sgx#76a5bed94dc31c32bd1670dbf72877abcf9bbc09"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits 0.2.10",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.41"
+source = "git+https://github.com/mesalock-linux/num-integer-sgx#404c50e5378ca635261688b080dee328ff42b6bd"
+dependencies = [
+ "autocfg 0.1.7",
+ "num-traits 0.2.10",
+ "sgx_tstd",
+]
 
 [[package]]
 name = "num-traits"
@@ -342,6 +472,12 @@ checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -494,6 +630,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd160"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "ripple-address-codec"
+version = "0.1.1"
+source = "git+https://github.com/ntls-io/ripple-address-codec-rust-sgx?branch=v0.1.1-sgx#e2b03486a9e0627bbc922681863b4661be8a4e3b"
+dependencies = [
+ "base-x",
+ "ring",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "ripple-keypairs"
+version = "0.1.0"
+source = "git+https://github.com/ntls-io/ripple-keypairs-rust-sgx?branch=v0.1.0-sgx#ef55261e2f0aa6b5c54cac43abc4c57b4f97b286"
+dependencies = [
+ "base-x",
+ "hex",
+ "libsecp256k1",
+ "num-bigint",
+ "ring",
+ "ripemd160",
+ "ripple-address-codec",
+ "sgx_tstd",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.9"
 source = "git+https://github.com/mesalock-linux/msgpack-rust-sgx#55273d79a63a08bdfe06d744e635296875307b22"
@@ -627,6 +799,8 @@ dependencies = [
  "base64",
  "hex",
  "rand 0.7.3",
+ "ripple-address-codec",
+ "ripple-keypairs",
  "rmp-serde",
  "secrecy",
  "serde",
@@ -775,15 +949,27 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.8.0"
+source = "git+https://github.com/mesalock-linux/rustcrypto-hashes-sgx#54ac4af765ec6b424add4e7559e82328bd052060"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "sha2"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
- "opaque-debug",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -814,6 +1000,14 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.2.2"
+source = "git+https://github.com/mesalock-linux/subtle-sgx#8ee32fc0902a4594bd12e272357e2d76cde9dad1"
+dependencies = [
+ "sgx_tstd",
+]
 
 [[package]]
 name = "syn"

--- a/web-server/sgx-wallet-test/enclave/Cargo.toml
+++ b/web-server/sgx-wallet-test/enclave/Cargo.toml
@@ -30,6 +30,7 @@ sgx_types = { git = "https://github.com/apache/incubator-teaclave-sgx-sdk", rev 
 # Community SGX forks
 rmp-serde = { git = "https://github.com/mesalock-linux/msgpack-rust-sgx" }
 serde = { git = "https://github.com/mesalock-linux/serde-sgx" }
+serde_json = { git = "https://github.com/mesalock-linux/serde-json-sgx" }
 
 # Our SGX forks
 algonaut = { git = "https://github.com/registreerocks/algonaut-sgx", branch = "main-sgx" }

--- a/web-server/sgx-wallet-test/enclave/src/lib.rs
+++ b/web-server/sgx-wallet-test/enclave/src/lib.rs
@@ -30,7 +30,7 @@ pub extern "C" fn run_tests_ecall() -> usize {
         ported::test_kv_store_fs::prop_fs_safe_roundtrip,
         schema::test_sealing::prop_seal_unseal_msgpack_roundtrips,
         schema::test_sealing::prop_seal_unseal_roundtrips,
-        schema::test_types::test_xrp_key_type_serde,
+        schema::test_types::test_xrpl_key_type_serde,
         wallet_operations::test_create_wallet::create_wallet_works,
         wallet_operations::test_dispatch::wallet_operation_sealing_works,
         wallet_operations::test_open_wallet::open_wallet_bad_pin,
@@ -40,6 +40,7 @@ pub extern "C" fn run_tests_ecall() -> usize {
         wallet_operations::test_sign_transaction::sign_transaction_malformed_transaction,
         wallet_operations::test_sign_transaction::sign_transaction_without_tag,
         wallet_operations::test_sign_transaction::sign_transaction_works,
+        wallet_operations::test_sign_transaction_xrpl::sign_transaction_empty,
         wallet_operations::test_sign_transaction_msgpack::prop_transaction_msgpack_roundtrips,
     )
 }

--- a/web-server/sgx-wallet-test/enclave/src/lib.rs
+++ b/web-server/sgx-wallet-test/enclave/src/lib.rs
@@ -30,6 +30,7 @@ pub extern "C" fn run_tests_ecall() -> usize {
         ported::test_kv_store_fs::prop_fs_safe_roundtrip,
         schema::test_sealing::prop_seal_unseal_msgpack_roundtrips,
         schema::test_sealing::prop_seal_unseal_roundtrips,
+        schema::test_types::test_xrp_key_type_serde,
         wallet_operations::test_create_wallet::create_wallet_works,
         wallet_operations::test_dispatch::wallet_operation_sealing_works,
         wallet_operations::test_open_wallet::open_wallet_bad_pin,

--- a/web-server/sgx-wallet-test/enclave/src/schema/mod.rs
+++ b/web-server/sgx-wallet-test/enclave/src/schema/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod test_sealing;
+pub(crate) mod test_types;

--- a/web-server/sgx-wallet-test/enclave/src/schema/test_types.rs
+++ b/web-server/sgx-wallet-test/enclave/src/schema/test_types.rs
@@ -1,0 +1,20 @@
+//! Test [`sgx_wallet_impl::schema::types`]
+
+use serde_json::Value;
+use sgx_wallet_impl::schema::types::XrplKeyType;
+
+/// [`XrplKeyType`] serializes to the same lowercase string constants used throughout the XRP Ledger.
+pub(crate) fn test_xrpl_key_type_serde() {
+    let pairs = [
+        (XrplKeyType::Secp256k1, "secp256k1"),
+        (XrplKeyType::Ed25519, "ed25519"),
+    ];
+    for (key_type, expected) in pairs {
+        let expected_json = Value::from(expected);
+        assert_eq!(serde_json::to_value(&key_type).unwrap(), expected_json);
+        assert_eq!(
+            serde_json::from_value::<XrplKeyType>(expected_json).unwrap(),
+            key_type
+        );
+    }
+}

--- a/web-server/sgx-wallet-test/enclave/src/wallet_operations/mod.rs
+++ b/web-server/sgx-wallet-test/enclave/src/wallet_operations/mod.rs
@@ -3,3 +3,4 @@ pub(crate) mod test_dispatch;
 pub(crate) mod test_open_wallet;
 pub(crate) mod test_sign_transaction;
 pub(crate) mod test_sign_transaction_msgpack;
+pub(crate) mod test_sign_transaction_xrpl;

--- a/web-server/sgx-wallet-test/enclave/src/wallet_operations/test_create_wallet.rs
+++ b/web-server/sgx-wallet-test/enclave/src/wallet_operations/test_create_wallet.rs
@@ -2,6 +2,7 @@ use std::prelude::v1::ToString;
 
 use sgx_wallet_impl::schema::actions;
 use sgx_wallet_impl::schema::actions::CreateWalletResult as Result;
+use sgx_wallet_impl::schema::entities::XrplAccountDisplay;
 use sgx_wallet_impl::wallet_operations::create_wallet::create_wallet;
 use sgx_wallet_impl::wallet_operations::store::load_wallet;
 
@@ -23,5 +24,13 @@ pub(crate) fn create_wallet_works() {
     assert_eq!(
         display.algorand_address_base32,
         stored.algorand_account.address_base32()
+    );
+    assert_eq!(
+        display.xrpl_account,
+        XrplAccountDisplay {
+            key_type: stored.xrpl_account.key_type,
+            public_key_hex: stored.xrpl_account.to_public_key_hex(),
+            address_base58: stored.xrpl_account.to_address_base58()
+        }
     );
 }

--- a/web-server/sgx-wallet-test/enclave/src/wallet_operations/test_dispatch.rs
+++ b/web-server/sgx-wallet-test/enclave/src/wallet_operations/test_dispatch.rs
@@ -16,8 +16,8 @@ pub(crate) fn wallet_operation_sealing_works() {
 
     // Seal
     let wallet_request = &WalletRequest::OpenWallet(OpenWallet {
-        wallet_id: "123".to_string(),
-        auth_pin: "456".to_string(),
+        wallet_id: "123456".to_string(),
+        auth_pin: "1234".to_string(),
     });
     let sealed_request_bytes =
         &seal_msgpack(wallet_request, &enclave_crypto.get_pubkey(), client_crypto).unwrap();
@@ -32,6 +32,9 @@ pub(crate) fn wallet_operation_sealing_works() {
     // Check
     assert_eq!(
         unsealed_message,
-        OpenWalletResult::Failed("key_from_id failed for wallet_id = \"123\": Error decoding base32: DecodeError { position: 2, kind: Length }".to_string()).into()
+        OpenWalletResult::Failed(
+            "key_from_id failed for wallet_id = \"123456\": decode error".to_string()
+        )
+        .into()
     );
 }

--- a/web-server/sgx-wallet-test/enclave/src/wallet_operations/test_sign_transaction_xrpl.rs
+++ b/web-server/sgx-wallet-test/enclave/src/wallet_operations/test_sign_transaction_xrpl.rs
@@ -1,0 +1,32 @@
+use std::prelude::v1::ToString;
+
+use sgx_wallet_impl::schema::actions;
+use sgx_wallet_impl::schema::actions::{TransactionSigned, TransactionToSign};
+use sgx_wallet_impl::wallet_operations::sign_transaction::sign_transaction;
+
+use crate::helpers::wallet_store::create_test_wallet;
+
+pub(crate) fn sign_transaction_empty() {
+    let existing = &create_test_wallet();
+
+    let transaction_bytes = Default::default();
+
+    let request = &actions::SignTransaction {
+        wallet_id: existing.wallet_id.clone(),
+        auth_pin: "123456".to_string(),
+        transaction_to_sign: TransactionToSign::XrplTransaction { transaction_bytes },
+    };
+    let signed = sign_transaction(request).unwrap_signed();
+
+    match signed {
+        TransactionSigned::XrplTransactionSigned {
+            signed_transaction_bytes: _,
+            signature_bytes,
+        } => {
+            assert_eq!(signature_bytes[0], 0x30); // DER tag for SEQUENCE
+        }
+        otherwise => panic!("unexpected: {:?}", otherwise),
+    }
+
+    // TODO(Pi): Test more substantially.
+}

--- a/web-server/sgx-wallet/enclave/Cargo.lock
+++ b/web-server/sgx-wallet/enclave/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "sgx_tstd",
- "sha2",
+ "sha2 0.9.5",
  "static_assertions",
  "thiserror",
 ]
@@ -43,7 +43,7 @@ dependencies = [
  "ring",
  "serde",
  "sgx_tstd",
- "sha2",
+ "sha2 0.9.5",
  "static_assertions",
  "thiserror",
 ]
@@ -76,10 +76,16 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sgx_tstd",
- "sha2",
+ "sha2 0.9.5",
  "thiserror",
  "url",
 ]
+
+[[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "autocfg"
@@ -94,6 +100,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,11 +113,30 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.1.4"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
+dependencies = [
+ "byte-tools",
 ]
 
 [[package]]
@@ -113,6 +144,11 @@ name = "bumpalo"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c59e7af012c713f529e7a3ee57ce9b31ddd858d4b512923602f74608b009631"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
 
 [[package]]
 name = "byteorder"
@@ -156,6 +192,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-mac"
+version = "0.8.0"
+source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
+dependencies = [
+ "generic-array 0.12.4",
+ "subtle",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -176,11 +227,35 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
+dependencies = [
+ "generic-array 0.12.4",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -233,6 +308,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.7.1"
+source = "git+https://github.com/mesalock-linux/rustcrypto-MACs-sgx#e8e1410b9c82d2e59da42fa8b0d8ed38e80a203c"
+dependencies = [
+ "crypto-mac",
+ "digest 0.8.1",
+]
+
+[[package]]
+name = "hmac-drbg"
+version = "0.1.2"
+source = "git+https://github.com/mesalock-linux/hmac-drbg-rs-sgx#89d6b0113157599417af867a8d2b4afd5c6f1946"
+dependencies = [
+ "generic-array 0.12.4",
+ "hmac",
+]
 
 [[package]]
 name = "idna"
@@ -294,6 +387,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7f823d141fe0a24df1e23b4af4e3c7ba9e5966ec514ea068c93024aa7deb765"
 
 [[package]]
+name = "libsecp256k1"
+version = "0.3.5"
+source = "git+https://github.com/ntls-io/libsecp256k1-rs-sgx#2a6c35a1876b3553486d34142155b89eaae77965"
+dependencies = [
+ "arrayref",
+ "crunchy",
+ "digest 0.8.1",
+ "hmac-drbg",
+ "rand",
+ "sgx_tstd",
+ "sha2 0.8.0",
+ "subtle",
+ "typenum",
+]
+
+[[package]]
 name = "log"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +417,27 @@ version = "0.1.8"
 source = "git+https://github.com/mesalock-linux/rust-std-candidates-sgx#5747bcf37f3e18687758838da0339ff0f2c83924"
 
 [[package]]
+name = "num-bigint"
+version = "0.2.5"
+source = "git+https://github.com/mesalock-linux/num-bigint-sgx#76a5bed94dc31c32bd1670dbf72877abcf9bbc09"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.41"
+source = "git+https://github.com/mesalock-linux/num-integer-sgx#404c50e5378ca635261688b080dee328ff42b6bd"
+dependencies = [
+ "autocfg 0.1.7",
+ "num-traits",
+ "sgx_tstd",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.10"
 source = "git+https://github.com/mesalock-linux/num-traits-sgx#af046e0b15c594c960007418097dd4ff37ec3f7a"
@@ -315,6 +445,12 @@ dependencies = [
  "autocfg 0.1.7",
  "sgx_tstd",
 ]
+
+[[package]]
+name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -398,6 +534,42 @@ dependencies = [
  "sgx_tstd",
  "spin",
  "untrusted",
+]
+
+[[package]]
+name = "ripemd160"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eca4ecc81b7f313189bf73ce724400a07da2a6dac19588b03c8bd76a2dcc251"
+dependencies = [
+ "block-buffer 0.9.0",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "ripple-address-codec"
+version = "0.1.1"
+source = "git+https://github.com/ntls-io/ripple-address-codec-rust-sgx?branch=v0.1.1-sgx#e2b03486a9e0627bbc922681863b4661be8a4e3b"
+dependencies = [
+ "base-x",
+ "ring",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "ripple-keypairs"
+version = "0.1.0"
+source = "git+https://github.com/ntls-io/ripple-keypairs-rust-sgx?branch=v0.1.0-sgx#ef55261e2f0aa6b5c54cac43abc4c57b4f97b286"
+dependencies = [
+ "base-x",
+ "hex",
+ "libsecp256k1",
+ "num-bigint",
+ "ring",
+ "ripemd160",
+ "ripple-address-codec",
+ "sgx_tstd",
 ]
 
 [[package]]
@@ -519,6 +691,8 @@ dependencies = [
  "base64",
  "hex",
  "rand",
+ "ripple-address-codec",
+ "ripple-keypairs",
  "rmp-serde",
  "secrecy",
  "serde",
@@ -631,15 +805,27 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.8.0"
+source = "git+https://github.com/mesalock-linux/rustcrypto-hashes-sgx#54ac4af765ec6b424add4e7559e82328bd052060"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+ "sgx_tstd",
+]
+
+[[package]]
+name = "sha2"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.9.0",
  "cfg-if 1.0.0",
  "cpufeatures",
- "digest",
- "opaque-debug",
+ "digest 0.9.0",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -670,6 +856,14 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "subtle"
+version = "2.2.2"
+source = "git+https://github.com/mesalock-linux/subtle-sgx#8ee32fc0902a4594bd12e272357e2d76cde9dad1"
+dependencies = [
+ "sgx_tstd",
+]
 
 [[package]]
 name = "syn"


### PR DESCRIPTION
This adds XRPL support to the `web-server` enclave, and corresponding representation types to the `web-client` schema.

Note that this branch currently switches from doubling the Algorand account as the wallet ID to doubling the XRPL account as wallet ID: see `key_from_id`. We should file a follow-up issue to address this.

### Related

- Issue: https://github.com/ntls-io/nautilus-wallet/issues/115
- Follows https://github.com/ntls-io/nautilus-wallet/pull/179
- Precedes https://github.com/ntls-io/nautilus-wallet/pull/169