### PR TITLE
test(web-client): disable flaky ScannerPage test

### DIFF
--- a/web-client/src/app/views/scanner/scanner.page.spec.ts
+++ b/web-client/src/app/views/scanner/scanner.page.spec.ts
@@ -34,7 +34,9 @@ describe('ScannerPage', () => {
     })
   );
 
-  it('should create', () => {
+  // FIXME(2022-04-28, Pi): This test fails intermittently with "Uncaught (in promise): overlay does not exist"
+  //                        Disable this until until we resolve that.
+  xit('should create', () => {
     expect(component).toBeTruthy();
   });
 


### PR DESCRIPTION
We're currently having to retry a lot of CI jobs due to this.