### PR TITLE
refactor(web-client): session services transaction signing

### DIFF
--- a/web-client/src/app/state/session-algorand.service.spec.ts
+++ b/web-client/src/app/state/session-algorand.service.spec.ts
@@ -5,16 +5,16 @@ import { SessionStore } from './session.store';
 
 describe('SessionAlgorandService', () => {
   let sessionAlgorandService: SessionAlgorandService;
-  let sessionAlgorandStore: SessionStore;
+  let sessionStore: SessionStore;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [SessionAlgorandService, SessionStore],
       imports: [HttpClientTestingModule],
+      providers: [SessionAlgorandService, SessionStore],
     });
 
     sessionAlgorandService = TestBed.inject(SessionAlgorandService);
-    sessionAlgorandStore = TestBed.inject(SessionStore);
+    sessionStore = TestBed.inject(SessionStore);
   });
 
   it('should be created', () => {

--- a/web-client/src/app/state/session.service.ts
+++ b/web-client/src/app/state/session.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { EnclaveService } from 'src/app/services/enclave/index';
 import { SessionQuery } from 'src/app/state/session.query';
+import { panic } from 'src/app/utils/errors/panic';
 import { never } from 'src/helpers/helpers';
 import {
   CreateWallet,
@@ -41,6 +42,7 @@ export class SessionService {
         this.sessionStore.update({ wallet, pin });
       } else if ('Failed' in result) {
         this.sessionStore.setError(result);
+        throw panic('SessionService: createWallet failed', result);
       } else {
         never(result);
       }

--- a/web-client/src/app/state/session.service.ts
+++ b/web-client/src/app/state/session.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { EnclaveService } from 'src/app/services/enclave/index';
-import { SessionAlgorandService } from 'src/app/state/session-algorand.service';
 import { SessionQuery } from 'src/app/state/session.query';
 import { never } from 'src/helpers/helpers';
 import {
@@ -23,8 +22,7 @@ export class SessionService {
   constructor(
     private sessionStore: SessionStore,
     private sessionQuery: SessionQuery,
-    private enclaveService: EnclaveService,
-    private sessionAlgorandService: SessionAlgorandService
+    private enclaveService: EnclaveService
   ) {}
 
   /**
@@ -68,9 +66,6 @@ export class SessionService {
     if ('Opened' in result) {
       const wallet = result.Opened;
       this.sessionStore.update({ wallet, pin });
-
-      // FIXME(Pi): This update should not be happening here.
-      await this.sessionAlgorandService.loadAccountData();
 
       return undefined; // Success
     } else if ('InvalidAuth' in result) {


### PR DESCRIPTION
- Factor out `SessionService.signTransaction` from `SessionAlgorandService.sendTransaction`
- Make `SessionAlgorandService` depend on `SessionService`, rather than the other way around

### Related

- Follows https://github.com/ntls-io/nautilus-wallet/pull/122
- Precedes https://github.com/ntls-io/nautilus-wallet/pull/185