### PR TITLE
feat(web-client): add XRPL session state and SessionXrplService

### DIFF
--- a/web-client/.storybook/preview.js
+++ b/web-client/.storybook/preview.js
@@ -9,6 +9,10 @@ import compodocJson from "../documentation.json";
 
 setCompodocJson(compodocJson);
 
+// Inject our polyfills into the Storybook preview.
+// (This is required for everything that relies on polyfills, such as XRPL.js.)
+require("src/polyfills");
+
 /** @type {import("@storybook/angular").Parameters} */
 export const parameters = {
   actions: { argTypesRegex: "^on[A-Z].*" },

--- a/web-client/package-lock.json
+++ b/web-client/package-lock.json
@@ -45,6 +45,7 @@
         "inputmask": "^5.0.6",
         "ngx-printer": "^1.0.0",
         "onfido-sdk-ui": "^6.15.5",
+        "ripple-keypairs": "^1.1.3",
         "rxjs": "^7.5.5",
         "sweetalert2": "^11.3.0",
         "tailwindcss-children": "^2.1.0",

--- a/web-client/package.json
+++ b/web-client/package.json
@@ -61,6 +61,7 @@
     "inputmask": "^5.0.6",
     "ngx-printer": "^1.0.0",
     "onfido-sdk-ui": "^6.15.5",
+    "ripple-keypairs": "^1.1.3",
     "rxjs": "^7.5.5",
     "sweetalert2": "^11.3.0",
     "tailwindcss-children": "^2.1.0",

--- a/web-client/src/app/services/xrpl.utils.spec.ts
+++ b/web-client/src/app/services/xrpl.utils.spec.ts
@@ -1,0 +1,74 @@
+import * as xrpl from 'xrpl';
+import {
+  hexToUint8Array,
+  txnAfterSign,
+  txnBeforeSign,
+  uint8ArrayToHex,
+} from './xrpl.utils';
+
+describe('signing helpers', () => {
+  // Some example expected transaction values:
+
+  const txnUnsigned: xrpl.Payment = {
+    Account: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn',
+    TransactionType: 'Payment',
+    Amount: '1234',
+    Destination: 'rf1BiGeXwwQoi8Z2ueFYTEXSwuJYfV2Jpn',
+  };
+
+  const signingPubKey = 'signingPubKey';
+  const txnBeingSigned: xrpl.Payment = {
+    ...txnUnsigned,
+    SigningPubKey: signingPubKey,
+  };
+
+  const txnSignature = 'txnSignature';
+  const txnSigned: xrpl.Payment = {
+    ...txnBeingSigned,
+    TxnSignature: txnSignature,
+  };
+
+  describe('txnBeforeSign', () => {
+    it('works', () => {
+      expect(txnBeforeSign(txnUnsigned, signingPubKey)).toEqual({
+        txnBeingSigned,
+        bytesToSignEncoded:
+          '535458001200006140000000000004D2730081144B4E9C06F24296074F7BC48F92A97916C6DC5EA983144B4E9C06F24296074F7BC48F92A97916C6DC5EA9',
+      });
+    });
+  });
+
+  describe('txnAfterSign', () => {
+    it('works', () => {
+      expect(txnAfterSign(txnBeingSigned, txnSignature)).toEqual({
+        txnSigned,
+        txnSignedEncoded:
+          '1200006140000000000004D27300740081144B4E9C06F24296074F7BC48F92A97916C6DC5EA983144B4E9C06F24296074F7BC48F92A97916C6DC5EA9',
+      });
+    });
+  });
+});
+
+describe('hexToUint8Array', () => {
+  // Pending upstream bugfix: https://github.com/XRPLF/xrpl.js/pull/1977
+  xit('empty', () => {
+    expect(hexToUint8Array('')).toEqual(new Uint8Array([]));
+  });
+
+  it('some', () => {
+    expect(hexToUint8Array('ABCDEF')).toEqual(
+      new Uint8Array([0xab, 0xcd, 0xef])
+    );
+  });
+});
+
+describe('uint8ArrayToHex', () => {
+  it('empty', () => {
+    expect(uint8ArrayToHex(new Uint8Array([]))).toEqual('');
+  });
+  it('some', () => {
+    expect(uint8ArrayToHex(new Uint8Array([0xab, 0xcd, 0xef]))).toEqual(
+      'ABCDEF'
+    );
+  });
+});

--- a/web-client/src/app/services/xrpl.utils.ts
+++ b/web-client/src/app/services/xrpl.utils.ts
@@ -1,0 +1,81 @@
+/* eslint-disable max-len -- long URL in comment */
+/**
+ * Supporting code for XRPL.
+ *
+ * In particular, this provides a stand-alone implementation of the transaction
+ * signing logic that's otherwise tied up in the XRPL.js wallet code.
+ *
+ * @todo We should look at migrating this logic entirely into the enclave?
+ *
+ * @see https://github.com/XRPLF/xrpl-dev-portal/blob/master/content/concepts/payment-system-basics/transaction-basics/understanding-signatures-draft.md
+ * @see https://xrpl.org/serialization.html
+ * @see https://github.com/XRPLF/xrpl.js/blob/xrpl%402.2.1/packages/xrpl/src/Wallet/index.ts#L257-L305
+ */
+
+import { bytesToHex, hexToBytes } from 'ripple-keypairs/dist/utils';
+import * as xrpl from 'xrpl';
+
+/**
+ * Convenience type alias for simple hex-encoded binary data,
+ * as used throughout XRPL.
+ */
+export type HexString = string;
+
+/**
+ * Prepare to sign `txnUnsigned` with `signingPubKey`.
+ *
+ * This returns:
+ *
+ * - `txnBeingSigned`: `txnUnsigned` with `SigningPubKey` added
+ *
+ * - `bytesToSignEncoded`: As encoded by {@link xrpl.encodeForSigning},
+ *   ready for signature calculation
+ */
+export const txnBeforeSign = (
+  txnUnsigned: xrpl.Transaction,
+  signingPubKey: HexString
+): { txnBeingSigned: xrpl.Transaction; bytesToSignEncoded: HexString } => {
+  const txnBeingSigned: xrpl.Transaction = {
+    ...txnUnsigned,
+    SigningPubKey: signingPubKey,
+  };
+  return {
+    txnBeingSigned,
+    bytesToSignEncoded: xrpl.encodeForSigning(txnBeingSigned),
+  };
+};
+
+/**
+ * Combine `txnBeingSigned` with its `txnSignature`
+ *
+ * This returns:
+ *
+ * - `txnSigned`: `txnBeingSigned` with `TxnSignature` added
+ * - `txnSignedEncoded`: As encoded by {@link xrpl.encode},
+ *   ready for submission
+ */
+export const txnAfterSign = (
+  txnBeingSigned: xrpl.Transaction,
+  txnSignature: HexString
+): { txnSigned: xrpl.Transaction; txnSignedEncoded: HexString } => {
+  const txnSigned: xrpl.Transaction = {
+    ...txnBeingSigned,
+    TxnSignature: txnSignature,
+  };
+  return { txnSigned, txnSignedEncoded: xrpl.encode(txnSigned) };
+};
+
+/**
+ * Like {@link hexToBytes}, but produce {@link Uint8Array}.
+ */
+export const hexToUint8Array = (hex: HexString): Uint8Array =>
+  Uint8Array.from(hexToBytes(hex));
+
+/**
+ * Like {@link bytesToHex}, but consume {@link Uint8Array}.
+ *
+ * This mainly exists to work around this bug:
+ * - <https://github.com/XRPLF/xrpl.js/pull/1975>
+ */
+export const uint8ArrayToHex = (array: Uint8Array): HexString =>
+  bytesToHex(Array.from(array));

--- a/web-client/src/app/state/session-xrpl.service.spec.ts
+++ b/web-client/src/app/state/session-xrpl.service.spec.ts
@@ -1,0 +1,23 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { SessionXrplService } from './session-xrpl.service';
+import { SessionXrplStore } from './session-xrpl.store';
+
+describe('SessionXrplService', () => {
+  let sessionXrplService: SessionXrplService;
+  let sessionXrplStore: SessionXrplStore;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [SessionXrplService, SessionXrplStore],
+      imports: [HttpClientTestingModule],
+    });
+
+    sessionXrplService = TestBed.inject(SessionXrplService);
+    sessionXrplStore = TestBed.inject(SessionXrplStore);
+  });
+
+  it('should be created', () => {
+    expect(sessionXrplService).toBeDefined();
+  });
+});

--- a/web-client/src/app/state/session-xrpl.service.spec.ts
+++ b/web-client/src/app/state/session-xrpl.service.spec.ts
@@ -1,20 +1,20 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { SessionXrplService } from './session-xrpl.service';
-import { SessionXrplStore } from './session-xrpl.store';
+import { SessionStore } from './session.store';
 
 describe('SessionXrplService', () => {
   let sessionXrplService: SessionXrplService;
-  let sessionXrplStore: SessionXrplStore;
+  let sessionStore: SessionStore;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [SessionXrplService, SessionXrplStore],
       imports: [HttpClientTestingModule],
+      providers: [SessionXrplService, SessionStore],
     });
 
     sessionXrplService = TestBed.inject(SessionXrplService);
-    sessionXrplStore = TestBed.inject(SessionXrplStore);
+    sessionStore = TestBed.inject(SessionStore);
   });
 
   it('should be created', () => {

--- a/web-client/src/app/state/session-xrpl.service.ts
+++ b/web-client/src/app/state/session-xrpl.service.ts
@@ -1,0 +1,11 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { SessionXrplStore } from './session-xrpl.store';
+
+@Injectable({ providedIn: 'root' })
+export class SessionXrplService {
+  constructor(
+    private sessionXrplStore: SessionXrplStore,
+    private http: HttpClient
+  ) {}
+}

--- a/web-client/src/app/state/session-xrpl.service.ts
+++ b/web-client/src/app/state/session-xrpl.service.ts
@@ -1,11 +1,124 @@
-import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { SessionXrplStore } from './session-xrpl.store';
+import { EnclaveService } from 'src/app/services/enclave/index';
+import { XrplService } from 'src/app/services/xrpl.service';
+import {
+  hexToUint8Array,
+  txnAfterSign,
+  txnBeforeSign,
+  uint8ArrayToHex,
+} from 'src/app/services/xrpl.utils';
+import { SessionService } from 'src/app/state/session.service';
+import { panic } from 'src/app/utils/errors/panic';
+import { TransactionSigned, TransactionToSign } from 'src/schema/actions';
+import * as xrpl from 'xrpl';
+import { SessionQuery } from './session.query';
+import { SessionStore, XrplBalance } from './session.store';
 
+/**
+ * This service manages session state and operations related to the XRP ledger.
+ */
 @Injectable({ providedIn: 'root' })
 export class SessionXrplService {
   constructor(
-    private sessionXrplStore: SessionXrplStore,
-    private http: HttpClient
+    private sessionStore: SessionStore,
+    private sessionQuery: SessionQuery,
+    private sessionService: SessionService,
+    private enclaveService: EnclaveService,
+    private xrplService: XrplService
   ) {}
+
+  /**
+   * Load the current wallet's XRPL account info from {@link XrplService}.
+   *
+   * This updates:
+   *
+   * - {@link import('./session.store').SessionState#xrplAccountRoot}.
+   * - {@link import('./session.store').SessionState#xrplBalances}.
+   */
+  async loadAccountData(): Promise<void> {
+    const { wallet } = this.sessionQuery.assumeActiveSession();
+    const xrplAddress = wallet.xrpl_account.address_base58;
+
+    // TODO: Fetch the following in parallel, sharing a connection context.
+
+    // Get AccountRoot entry:
+    const accountInfo = await this.xrplService.getAccountInfo({
+      account: xrplAddress,
+    });
+    const xrplAccountRoot: xrpl.LedgerEntry.AccountRoot =
+      accountInfo.result.account_data;
+
+    // Get balances:
+    const xrplBalances: XrplBalance[] = await this.xrplService.getBalances(
+      xrplAddress
+    );
+
+    this.sessionStore.update({ xrplAccountRoot, xrplBalances });
+  }
+
+  async sendFunds(
+    receiverId: string,
+    amount: xrpl.Payment['Amount']
+  ): Promise<xrpl.TxResponse> {
+    const { wallet } = this.sessionQuery.assumeActiveSession();
+
+    const preparedTx: xrpl.Payment =
+      await this.xrplService.createUnsignedTransaction(
+        wallet.xrpl_account.address_base58,
+        receiverId,
+        amount
+      );
+
+    return await this.sendTransaction(preparedTx);
+  }
+
+  /**
+   * Helper: Sign, submit, and confirm the given transaction.
+   */
+  protected async sendTransaction(
+    txnUnsigned: xrpl.Transaction
+  ): Promise<xrpl.TxResponse> {
+    const { wallet } = this.sessionQuery.assumeActiveSession();
+
+    const { txnBeingSigned, bytesToSignEncoded } = txnBeforeSign(
+      txnUnsigned,
+      wallet.xrpl_account.public_key_hex
+    );
+
+    const transactionToSign: TransactionToSign = {
+      XrplTransaction: {
+        transaction_bytes: hexToUint8Array(bytesToSignEncoded),
+      },
+    };
+    const signed: TransactionSigned = await this.sessionService.signTransaction(
+      transactionToSign
+    );
+
+    if ('XrplTransactionSigned' in signed) {
+      console.log('SessionXrplService.sendTransaction:', { signed });
+      const { signature_bytes } = signed.XrplTransactionSigned;
+
+      const { txnSigned, txnSignedEncoded } = txnAfterSign(
+        txnBeingSigned,
+        uint8ArrayToHex(signature_bytes)
+      );
+      console.log('SessionXrplService.sendTransaction: after sign:', {
+        txnSigned,
+        txnSignedEncoded,
+      });
+
+      const txResponse: xrpl.TxResponse =
+        await this.xrplService.submitAndWaitForSigned(txnSignedEncoded);
+      console.log('SessionXrplService.sendTransaction', { txResponse });
+
+      await this.loadAccountData(); // FIXME(Pi): Move to caller?
+
+      return txResponse;
+    } else {
+      throw panic(
+        'SessionXrplService.sendTransaction: expected XrplTransactionSigned, got:',
+        signed
+      );
+    }
+  }
 }

--- a/web-client/src/app/state/session.query.spec.ts
+++ b/web-client/src/app/state/session.query.spec.ts
@@ -29,7 +29,11 @@ describe('SessionQuery', () => {
     expect(query).toBeTruthy();
   });
 
-  const stubState = (): Required<SessionState> => {
+  /** `SessionState` with some required fields, for convenience. */
+  type StubSessionState = SessionState &
+    Pick<Required<SessionState>, 'wallet' | 'pin' | 'algorandAccountData'>;
+
+  const stubState = (): StubSessionState => {
     const wallet: WalletDisplay = {
       wallet_id: 'id',
       owner_name: 'name',
@@ -40,7 +44,7 @@ describe('SessionQuery', () => {
         address_base58: 'address',
       },
     };
-    const state: Required<SessionState> = {
+    const state: StubSessionState = {
       wallet,
       pin: 'secret',
       algorandAccountData: {

--- a/web-client/src/app/state/session.query.spec.ts
+++ b/web-client/src/app/state/session.query.spec.ts
@@ -11,6 +11,14 @@ import {
   assetAmountAsa,
   AssetAmountAsa,
 } from 'src/app/utils/assets/assets.algo.asa';
+import {
+  AssetAmountXrp,
+  assetAmountXrp,
+} from 'src/app/utils/assets/assets.xrp';
+import {
+  AssetAmountXrplToken,
+  assetAmountXrplToken,
+} from 'src/app/utils/assets/assets.xrp.token';
 import { WalletDisplay } from 'src/schema/entities';
 import { stubActiveSession } from 'src/tests/state.helpers';
 import { SessionQuery } from './session.query';
@@ -31,7 +39,10 @@ describe('SessionQuery', () => {
 
   /** `SessionState` with some required fields, for convenience. */
   type StubSessionState = SessionState &
-    Pick<Required<SessionState>, 'wallet' | 'pin' | 'algorandAccountData'>;
+    Pick<
+      Required<SessionState>,
+      'wallet' | 'pin' | 'algorandAccountData' | 'xrplBalances'
+    >;
 
   const stubState = (): StubSessionState => {
     const wallet: WalletDisplay = {
@@ -61,6 +72,10 @@ describe('SessionQuery', () => {
           total: 10_000,
         },
       },
+      xrplBalances: [
+        { value: '1', currency: 'XRP' },
+        { value: '1', currency: 'PCT', issuer: 'PCT issuer' },
+      ],
     };
     store.update(state);
     return state;
@@ -113,50 +128,79 @@ describe('SessionQuery', () => {
     });
   });
 
-  describe('algorandAccountData fields', () => {
-    it('algorandBalanceInMicroAlgos', async () => {
-      expect(await get(query.algorandBalanceInMicroAlgos)).toBeUndefined();
-      const stub = stubState();
-      expect(await get(query.algorandBalanceInMicroAlgos)).toBe(
-        stub.algorandAccountData.amount
-      );
-    });
-
-    it('algorandBalanceInAlgos', async () => {
-      expect(await get(query.algorandBalanceInAlgos)).toBeUndefined();
-      const stub = stubState();
-      expect(await get(query.algorandBalanceInAlgos)).toBe(
-        convertToAlgos(stub.algorandAccountData.amount)
-      );
-    });
-
+  describe('balance fields', () => {
     const expectedAlgoBalance: AssetAmountAlgo = assetAmountAlgo(1);
 
     const expectedAssetBalances: AssetAmountAsa[] = [
       assetAmountAsa(1, { assetSymbol: 'PCT', assetId: 5, decimals: 2 }),
     ];
 
-    it('algorandAlgoBalance', async () => {
-      expect(await get(query.algorandAlgoBalance)).toBeUndefined();
-      stubState();
-      expect(await get(query.algorandAlgoBalance)).toEqual(assetAmountAlgo(1));
+    describe('Algorand balances', () => {
+      it('algorandBalanceInMicroAlgos', async () => {
+        expect(await get(query.algorandBalanceInMicroAlgos)).toBeUndefined();
+        const stub = stubState();
+        expect(await get(query.algorandBalanceInMicroAlgos)).toBe(
+          stub.algorandAccountData.amount
+        );
+      });
+
+      it('algorandBalanceInAlgos', async () => {
+        expect(await get(query.algorandBalanceInAlgos)).toBeUndefined();
+        const stub = stubState();
+        expect(await get(query.algorandBalanceInAlgos)).toBe(
+          convertToAlgos(stub.algorandAccountData.amount)
+        );
+      });
+
+      it('algorandAlgoBalance', async () => {
+        expect(await get(query.algorandAlgoBalance)).toBeUndefined();
+        stubState();
+        expect(await get(query.algorandAlgoBalance)).toEqual(
+          assetAmountAlgo(1)
+        );
+      });
+
+      it('algorandAssetBalances', async () => {
+        expect(await get(query.algorandAssetBalances)).toBeUndefined();
+        stubState();
+        expect(await get(query.algorandAssetBalances)).toEqual([
+          ...expectedAssetBalances,
+        ]);
+      });
+
+      it('algorandBalances', async () => {
+        expect(await get(query.algorandBalances)).toEqual([]);
+        stubState();
+        expect(await get(query.algorandBalances)).toEqual([
+          expectedAlgoBalance,
+          ...expectedAssetBalances,
+        ]);
+      });
     });
 
-    it('algorandAssetBalances', async () => {
-      expect(await get(query.algorandAssetBalances)).toBeUndefined();
-      stubState();
-      expect(await get(query.algorandAssetBalances)).toEqual([
-        ...expectedAssetBalances,
-      ]);
+    const expectedXrplBalances: (AssetAmountXrp | AssetAmountXrplToken)[] = [
+      assetAmountXrp(1),
+      assetAmountXrplToken(1, { currency: 'PCT', issuer: 'PCT issuer' }),
+    ];
+
+    describe('XRPL balances', () => {
+      it('xrplBalances', async () => {
+        expect(await get(query.xrplBalances)).toBe(undefined);
+        stubState();
+        expect(await get(query.xrplBalances)).toEqual(expectedXrplBalances);
+      });
     });
 
-    it('algorandBalances', async () => {
-      expect(await get(query.algorandBalances)).toEqual([]);
-      stubState();
-      expect(await get(query.algorandBalances)).toEqual([
-        expectedAlgoBalance,
-        ...expectedAssetBalances,
-      ]);
+    describe('combined balances', () => {
+      it('allBalances', async () => {
+        expect(await get(query.allBalances)).toEqual([]);
+        stubState();
+        expect(await get(query.allBalances)).toEqual([
+          expectedAlgoBalance,
+          ...expectedAssetBalances,
+          ...expectedXrplBalances,
+        ]);
+      });
     });
   });
 

--- a/web-client/src/app/state/session.store.ts
+++ b/web-client/src/app/state/session.store.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { Store, StoreConfig } from '@datorama/akita';
 import { AccountData, AssetParams } from 'src/app/services/algosdk.utils';
 import { WalletDisplay } from 'src/schema/entities';
+import * as xrpl from 'xrpl';
 
 /**
  * State stored for a user session.
@@ -35,7 +36,29 @@ export interface SessionState {
    * @see import('./session-algorand.service').SessionAlgorandService.loadAssetParams
    */
   algorandAssetParams?: Record<number, AssetParams>;
+
+  /**
+   * The current session's XRPL account root ledger entry.
+   *
+   * @see import('./session-xrpl.service').SessionXrplService
+   * @see https://js.xrpl.org/interfaces/LedgerEntry.AccountRoot.html
+   */
+  xrplAccountRoot?: xrpl.LedgerEntry.AccountRoot;
+
+  /**
+   * The current session's XRPL balances.
+   *
+   * @see import('./session-xrpl.service').SessionXrplService
+   * @see https://js.xrpl.org/classes/Client.html#getBalances
+   */
+  xrplBalances?: XrplBalance[];
 }
+
+export type XrplBalance = {
+  value: string;
+  currency: string;
+  issuer?: string | undefined;
+};
 
 export const createInitialState = (): SessionState => ({});
 

--- a/web-client/src/app/utils/assets/assets.xrp.spec.ts
+++ b/web-client/src/app/utils/assets/assets.xrp.spec.ts
@@ -2,6 +2,8 @@ import {
   assetAmountXrp,
   AssetAmountXrp,
   ASSET_DISPLAY_XRP,
+  convertFromAssetAmountXrpToLedger,
+  convertFromLedgerToAssetAmountXrp,
   LEDGER_INFO_XRPL,
 } from './assets.xrp';
 
@@ -13,5 +15,22 @@ describe('assetAmountXrp', () => {
       ledgerInfo: LEDGER_INFO_XRPL,
     };
     expect(assetAmountXrp(0)).toEqual(expected);
+  });
+});
+
+describe('ledger conversion', () => {
+  describe('convertFromLedgerToAssetAmountXrp', () => {
+    it('works', () => {
+      expect(convertFromLedgerToAssetAmountXrp('123456000')).toEqual(
+        assetAmountXrp(123.456)
+      );
+    });
+  });
+  describe('convertFromAssetAmountXrpToLedger', () => {
+    it('works', () => {
+      expect(
+        convertFromAssetAmountXrpToLedger(assetAmountXrp(123.456))
+      ).toEqual('123456000');
+    });
   });
 });

--- a/web-client/src/app/utils/assets/assets.xrp.token.spec.ts
+++ b/web-client/src/app/utils/assets/assets.xrp.token.spec.ts
@@ -1,0 +1,111 @@
+import {
+  assetAmountAlgo,
+  LEDGER_INFO_ALGORAND,
+} from 'src/app/utils/assets/assets.algo';
+import {
+  assetAmountXrp,
+  LEDGER_INFO_XRPL,
+  LEDGER_TYPE_XRPL,
+} from 'src/app/utils/assets/assets.xrp';
+import { IssuedCurrencyAmount } from 'xrpl/dist/npm/models/common/index';
+import {
+  AssetAmountXrplToken,
+  assetAmountXrplToken,
+  convertFromAssetAmountXrplTokenToLedger,
+  convertFromLedgerToAssetAmountXrplToken,
+  isAssetAmountXrplToken,
+  isLedgerInfoXrplToken,
+  ledgerInfoXrplToken,
+  LedgerInfoXrplToken,
+} from './assets.xrp.token';
+
+const exampleLedgerInfoXrplToken: LedgerInfoXrplToken = ledgerInfoXrplToken(
+  'SPAM',
+  'spammer'
+);
+
+const exampleAssetAmountXrplToken: AssetAmountXrplToken = assetAmountXrplToken(
+  12.34,
+  { currency: 'SPAM', issuer: 'spammer' }
+);
+
+describe('ledgerInfoXrplToken', () => {
+  it('constructs', () => {
+    const expected: LedgerInfoXrplToken = {
+      type: LEDGER_TYPE_XRPL,
+      isToken: true,
+      currency: 'SPAM',
+      issuer: 'spammer',
+    };
+    expect(exampleLedgerInfoXrplToken).toEqual(expected);
+  });
+});
+
+describe('assetAmountXrplToken', () => {
+  it('constructs', () => {
+    const expected: AssetAmountXrplToken = {
+      amount: 12.34,
+      assetDisplay: { assetSymbol: 'SPAM', minDigits: 0, maxDigits: 3 },
+      ledgerInfo: {
+        type: LEDGER_TYPE_XRPL,
+        isToken: true,
+        currency: 'SPAM',
+        issuer: 'spammer',
+      },
+    };
+    expect(
+      assetAmountXrplToken(12.34, { currency: 'SPAM', issuer: 'spammer' })
+    ).toEqual(expected);
+  });
+});
+
+describe('isLedgerInfoXrplToken', () => {
+  it('accepts XRPL token', () => {
+    expect(isLedgerInfoXrplToken(exampleLedgerInfoXrplToken)).toBeTrue();
+  });
+
+  it('rejects XRPL', () => {
+    expect(isLedgerInfoXrplToken(LEDGER_INFO_XRPL)).toBeFalse();
+  });
+
+  it('rejects Algorand', () => {
+    expect(isLedgerInfoXrplToken(LEDGER_INFO_ALGORAND)).toBeFalse();
+  });
+});
+
+describe('isAssetAmountXrplToken', () => {
+  it('accepts XRPL token', () => {
+    expect(isAssetAmountXrplToken(exampleAssetAmountXrplToken)).toBeTrue();
+  });
+
+  it('rejects XRP', () => {
+    expect(isAssetAmountXrplToken(assetAmountXrp(1))).toBeFalse();
+  });
+
+  it('rejects Algo', () => {
+    expect(isAssetAmountXrplToken(assetAmountAlgo(1))).toBeFalse();
+  });
+});
+
+describe('ledger conversion', () => {
+  const exampleLedgerAmountXrplToken: IssuedCurrencyAmount = {
+    currency: 'SPAM',
+    issuer: 'spammer',
+    value: '12.34',
+  };
+
+  describe('convertFromLedgerToAssetAmountXrplToken', () => {
+    it('works', () => {
+      expect(
+        convertFromLedgerToAssetAmountXrplToken(exampleLedgerAmountXrplToken)
+      ).toEqual(exampleAssetAmountXrplToken);
+    });
+  });
+  describe('convertFromAssetAmountXrplTokenToLedger', () => {
+    it('works', () => {
+      expect(
+        convertFromAssetAmountXrplTokenToLedger(exampleAssetAmountXrplToken)
+      ).toEqual(exampleLedgerAmountXrplToken);
+    });
+  });
+});

--- a/web-client/src/app/utils/assets/assets.xrp.token.ts
+++ b/web-client/src/app/utils/assets/assets.xrp.token.ts
@@ -1,0 +1,84 @@
+/**
+ * Types and code for working with tokens on the XRP ledger.
+ *
+ * 1. {@link AssetDisplay}: use common base type.
+ * 2. {@link LedgerInfo} constructor: {@link ledgerInfoXrplToken}
+ * 3. {@link AssetAmount} constructor: {@link assetAmountXrplToken}
+ */
+
+import {
+  LedgerTypeXrpl,
+  LEDGER_TYPE_XRPL,
+} from 'src/app/utils/assets/assets.xrp';
+import { defined } from 'src/app/utils/errors/panic';
+import { parseNumber } from 'src/app/utils/validators';
+import { IssuedCurrencyAmount } from 'xrpl/dist/npm/models/common/index';
+import { AssetAmount, LedgerInfo } from './assets.common';
+
+// LedgerInfo:
+
+export type LedgerInfoXrplToken = LedgerInfo & {
+  type: LedgerTypeXrpl;
+  isToken: true;
+  currency: string;
+  issuer: string;
+};
+
+export const ledgerInfoXrplToken = (
+  currency: string,
+  issuer: string
+): LedgerInfoXrplToken => ({
+  type: LEDGER_TYPE_XRPL,
+  isToken: true,
+  currency,
+  issuer,
+});
+
+// AssetAmount:
+
+export type AssetAmountXrplToken = AssetAmount & {
+  ledgerInfo: LedgerInfoXrplToken;
+};
+
+export const assetAmountXrplToken = (
+  amount: number,
+  { currency, issuer }: { currency: string; issuer: string }
+): AssetAmountXrplToken => ({
+  amount,
+  assetDisplay: { assetSymbol: currency, minDigits: 0, maxDigits: 3 },
+  ledgerInfo: ledgerInfoXrplToken(currency, issuer),
+});
+
+// Type checks:
+
+export const isLedgerInfoXrplToken = (
+  ledgerInfo: LedgerInfo | LedgerInfoXrplToken
+): ledgerInfo is LedgerInfoXrplToken =>
+  ledgerInfo.type === LEDGER_TYPE_XRPL &&
+  'isToken' in ledgerInfo &&
+  ledgerInfo.isToken &&
+  'currency' in ledgerInfo;
+
+export const isAssetAmountXrplToken = (
+  amount: AssetAmount
+): amount is AssetAmountXrplToken => isLedgerInfoXrplToken(amount.ledgerInfo);
+
+// Ledger representation conversion:
+
+export const convertFromLedgerToAssetAmountXrplToken = (
+  ledgerAmount: IssuedCurrencyAmount
+): AssetAmountXrplToken => {
+  const { currency, issuer, value } = ledgerAmount;
+  const amount = defined(parseNumber(value), `bad number: ${value}`);
+  return assetAmountXrplToken(amount, { currency, issuer });
+};
+
+export const convertFromAssetAmountXrplTokenToLedger = (
+  assetAmount: AssetAmountXrplToken
+): IssuedCurrencyAmount => {
+  const {
+    amount,
+    ledgerInfo: { currency, issuer },
+  } = assetAmount;
+  return { currency, issuer, value: amount.toString() };
+};

--- a/web-client/src/app/utils/assets/assets.xrp.ts
+++ b/web-client/src/app/utils/assets/assets.xrp.ts
@@ -5,7 +5,9 @@
  * 2. {@link LedgerInfo} constant: {@link LEDGER_INFO_XRPL}
  * 3. {@link AssetAmount} constructor: {@link assetAmountXrp}
  */
-
+import { defined } from 'src/app/utils/errors/panic';
+import { parseNumber } from 'src/app/utils/validators';
+import * as xrpl from 'xrpl';
 import { AssetAmount, AssetDisplay, LedgerInfo } from './assets.common';
 
 // AssetDisplay:
@@ -59,3 +61,19 @@ export const isAssetAmountXrp = (
 ): amount is AssetAmountXrp =>
   amount.ledgerInfo.type === LEDGER_TYPE_XRPL &&
   amount.assetDisplay.assetSymbol === ASSET_SYMBOL_XRP;
+
+// Ledger representation conversion:
+
+export const convertFromLedgerToAssetAmountXrp = (
+  ledgerAmount: string
+): AssetAmountXrp =>
+  assetAmountXrp(
+    defined(
+      parseNumber(xrpl.dropsToXrp(ledgerAmount)),
+      `bad number: ${ledgerAmount}`
+    )
+  );
+
+export const convertFromAssetAmountXrpToLedger = (
+  assetAmount: AssetAmountXrp
+): string => xrpl.xrpToDrops(assetAmount.amount);

--- a/web-client/src/app/utils/assets/assets.xrp.ts
+++ b/web-client/src/app/utils/assets/assets.xrp.ts
@@ -51,3 +51,11 @@ export const assetAmountXrp = (amount: number): AssetAmountXrp => ({
   assetDisplay: ASSET_DISPLAY_XRP,
   ledgerInfo: LEDGER_INFO_XRPL,
 });
+
+// Type checks:
+
+export const isAssetAmountXrp = (
+  amount: AssetAmount | AssetAmountXrp
+): amount is AssetAmountXrp =>
+  amount.ledgerInfo.type === LEDGER_TYPE_XRPL &&
+  amount.assetDisplay.assetSymbol === ASSET_SYMBOL_XRP;


### PR DESCRIPTION
This adds:

- `SessionState` fields: `xrplAccountRoot`, `xrplBalances`
- `SessionQuery` observables: `xrplBalances`, `allBalances`
- `SessionXrplService`, with operations: `loadAccountData`, `sendFunds`

along with supporting code:

- `xrpl.utils` (XRPL transaction signing helpers)
- `assets.xrp` & `assets.xrp.token` (asset amount representation helpers for XRP and XRPL tokens)

### Related

- Follows https://github.com/ntls-io/nautilus-wallet/pull/184
- Precedes https://github.com/ntls-io/nautilus-wallet/pull/187