### PR TITLE
test(web-client,PayComponent): bump Storybook load timeout again

### DIFF
--- a/web-client/src/app/components/pay/pay.component.stories.ts
+++ b/web-client/src/app/components/pay/pay.component.stories.ts
@@ -37,7 +37,7 @@ const xrpOption: PaymentOption = {
 };
 
 /** This component needs more than the default 1 second to load. */
-const LOAD_TIMEOUT: milliseconds = 4_000;
+const LOAD_TIMEOUT: milliseconds = 8_000;
 type milliseconds = number;
 
 const Template: Story<PayComponent> = (args: PayComponent) => ({

--- a/web-client/src/app/components/pay/pay.component.stories.ts
+++ b/web-client/src/app/components/pay/pay.component.stories.ts
@@ -10,10 +10,18 @@ import { ionicStoryMeta } from 'src/stories/storybook.helpers';
 import { PayComponent, PaymentOption } from './pay.component';
 import { PayComponentModule } from './pay.module';
 
+/** This component needs more than the default 1 second to load. */
+const LOAD_TIMEOUT: milliseconds = 8_000;
+type milliseconds = number;
+
 export default ionicStoryMeta<PayComponent>(
   {
     title: 'Components/Pay/Pay',
     component: PayComponent,
+    parameters: {
+      // https://www.chromatic.com/docs/delay
+      chromatic: { delay: LOAD_TIMEOUT },
+    },
   },
   {
     imports: [PayComponentModule],
@@ -35,10 +43,6 @@ const xrpOption: PaymentOption = {
   senderBalance: PayFromToXRPArgs.balance,
   receiverAddress: PayFromToXRPArgs.receiverAddress,
 };
-
-/** This component needs more than the default 1 second to load. */
-const LOAD_TIMEOUT: milliseconds = 8_000;
-type milliseconds = number;
 
 const Template: Story<PayComponent> = (args: PayComponent) => ({
   props: {


### PR DESCRIPTION
4s still managed to hit a timeout: hopefully 8s is better.

This also uses the timeout for the Chromatic snapshot delay, to avoid unreliable snapshots.

### Related

- https://github.com/ntls-io/nautilus-wallet/pull/181