### PR TITLE
feat(web-client): add XRP & XRPL tokens to Pay & Wallet pages

### DIFF
--- a/web-client/src/app/components/pure-pay-page/pure-pay-page.component.ts
+++ b/web-client/src/app/components/pure-pay-page/pure-pay-page.component.ts
@@ -10,6 +10,7 @@ import {
 import algosdk from 'algosdk';
 import { Payment, PaymentOption } from 'src/app/components/pay/pay.component';
 import { AssetAmount } from 'src/app/utils/assets/assets.common';
+import * as xrpl from 'xrpl';
 
 /**
  * @see PayPage
@@ -25,6 +26,8 @@ export class PurePayPageComponent implements OnInit, OnChanges {
   @Input() receiverAddress?: string | null;
 
   @Input() algorandBalances?: AssetAmount[] | null;
+
+  @Input() xrplBalances?: AssetAmount[] | null;
 
   @Output() paymentSubmitted = new EventEmitter<Payment>();
 
@@ -66,16 +69,25 @@ export class PurePayPageComponent implements OnInit, OnChanges {
           senderBalance,
           receiverAddress,
         }));
+      } else if (this.receiverAddressType === 'XRPL' && this.xrplBalances) {
+        return this.xrplBalances.map((senderBalance) => ({
+          senderName,
+          senderBalance,
+          receiverAddress,
+        }));
       }
     }
   }
 }
 
-type AddressType = 'Algorand';
+type AddressType = 'Algorand' | 'XRPL';
 
 const addressTypes = (address: string): AddressType[] => {
   const coerce = (t: AddressType[]) => t;
-  return [...coerce(algosdk.isValidAddress(address) ? ['Algorand'] : [])];
+  return [
+    ...coerce(algosdk.isValidAddress(address) ? ['Algorand'] : []),
+    ...coerce(xrpl.isValidAddress(address) ? ['XRPL'] : []),
+  ];
 };
 
 const addressType = (address: string): AddressType | undefined => {

--- a/web-client/src/app/state/session-xrpl.service.ts
+++ b/web-client/src/app/state/session-xrpl.service.ts
@@ -8,6 +8,7 @@ import {
   uint8ArrayToHex,
 } from 'src/app/services/xrpl.utils';
 import { SessionService } from 'src/app/state/session.service';
+import { withLoggedExchange } from 'src/app/utils/console.helpers';
 import { panic } from 'src/app/utils/errors/panic';
 import { TransactionSigned, TransactionToSign } from 'src/schema/actions';
 import * as xrpl from 'xrpl';
@@ -62,12 +63,16 @@ export class SessionXrplService {
   ): Promise<xrpl.TxResponse> {
     const { wallet } = this.sessionQuery.assumeActiveSession();
 
-    const preparedTx: xrpl.Payment =
-      await this.xrplService.createUnsignedTransaction(
-        wallet.xrpl_account.address_base58,
-        receiverId,
-        amount
-      );
+    const preparedTx: xrpl.Payment = await withLoggedExchange(
+      'SessionXrplService.sendFunds: XrplService.createUnsignedTransaction:',
+      async () =>
+        await this.xrplService.createUnsignedTransaction(
+          wallet.xrpl_account.address_base58,
+          receiverId,
+          amount
+        ),
+      { from: wallet.xrpl_account.address_base58, to: receiverId, amount }
+    );
 
     return await this.sendTransaction(preparedTx);
   }
@@ -95,21 +100,19 @@ export class SessionXrplService {
     );
 
     if ('XrplTransactionSigned' in signed) {
-      console.log('SessionXrplService.sendTransaction:', { signed });
       const { signature_bytes } = signed.XrplTransactionSigned;
 
       const { txnSigned, txnSignedEncoded } = txnAfterSign(
         txnBeingSigned,
         uint8ArrayToHex(signature_bytes)
       );
-      console.log('SessionXrplService.sendTransaction: after sign:', {
-        txnSigned,
-        txnSignedEncoded,
-      });
 
-      const txResponse: xrpl.TxResponse =
-        await this.xrplService.submitAndWaitForSigned(txnSignedEncoded);
-      console.log('SessionXrplService.sendTransaction', { txResponse });
+      const txResponse: xrpl.TxResponse = await withLoggedExchange(
+        'SessionXrplService.sendTransaction: signed, submitting:',
+        async () =>
+          await this.xrplService.submitAndWaitForSigned(txnSignedEncoded),
+        txnSignedEncoded
+      );
 
       await this.loadAccountData(); // FIXME(Pi): Move to caller?
 

--- a/web-client/src/app/state/session-xrpl.service.ts
+++ b/web-client/src/app/state/session-xrpl.service.ts
@@ -79,6 +79,8 @@ export class SessionXrplService {
 
   /**
    * Helper: Sign, submit, and confirm the given transaction.
+   *
+   * NOTE: This does not check for success: the caller is responsible for that.
    */
   protected async sendTransaction(
     txnUnsigned: xrpl.Transaction

--- a/web-client/src/app/state/session.service.ts
+++ b/web-client/src/app/state/session.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { EnclaveService } from 'src/app/services/enclave/index';
 import { SessionQuery } from 'src/app/state/session.query';
+import { withLoggedExchange } from 'src/app/utils/console.helpers';
 import { panic } from 'src/app/utils/errors/panic';
 import { never } from 'src/helpers/helpers';
 import {
@@ -98,8 +99,11 @@ export class SessionService {
       wallet_id: wallet.wallet_id,
       transaction_to_sign,
     };
-    const signResult: SignTransactionResult =
-      await this.enclaveService.signTransaction(signRequest);
+    const signResult: SignTransactionResult = await withLoggedExchange(
+      'SessionService: EnclaveService.signTransaction:',
+      async () => await this.enclaveService.signTransaction(signRequest),
+      signRequest
+    );
 
     if ('Signed' in signResult) {
       return signResult.Signed;

--- a/web-client/src/app/utils/console.helpers.ts
+++ b/web-client/src/app/utils/console.helpers.ts
@@ -1,0 +1,45 @@
+/**
+ * Console logging helpers.
+ */
+
+export const withConsoleGroup = async <R>(
+  label: string,
+  f: () => Promise<R>
+): Promise<R> => {
+  console.group(label);
+  try {
+    return await f();
+  } finally {
+    console.groupEnd();
+  }
+};
+
+export const withConsoleTimer = async <R>(
+  label: string,
+  f: () => Promise<R>
+): Promise<R> => {
+  // eslint-disable-next-line no-console
+  console.time(label);
+  try {
+    return await f();
+  } finally {
+    // eslint-disable-next-line no-console
+    console.timeEnd(label);
+  }
+};
+
+export const withLoggedExchange = async <Request, Response>(
+  label: string,
+  f: (request: Request) => Promise<Response>,
+  request: Request
+): Promise<Response> =>
+  await withConsoleGroup(
+    label,
+    async () =>
+      await withConsoleTimer('exchange', async () => {
+        console.log('request:', request);
+        const response = await f(request);
+        console.log('response:', response);
+        return response;
+      })
+  );

--- a/web-client/src/app/views/manual-address/manual-address.page.ts
+++ b/web-client/src/app/views/manual-address/manual-address.page.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ModalController } from '@ionic/angular';
-import { isValidAddress } from 'algosdk';
 import { checkClass } from 'src/helpers/helpers';
 
 @Component({
@@ -42,7 +41,7 @@ export class ManualAddressPage implements OnInit {
 
 const addressValidator = (formGroup: FormControl) => {
   const address = trimmedValue(formGroup);
-  return isValidAddress(address) ? null : { invalidAddress: true };
+  return address ? null : { invalidAddress: true };
 };
 
 const trimmedValue = (formControl: FormControl) => {

--- a/web-client/src/app/views/pay/pay.page.html
+++ b/web-client/src/app/views/pay/pay.page.html
@@ -8,6 +8,7 @@
       [senderName]="senderName | async"
       [receiverAddress]="receiverAddress | async"
       [algorandBalances]="algorandBalances | async"
+      [xrplBalances]="xrplBalances | async"
       (paymentSubmitted)="onPaymentSubmitted($event)"
       [autofocus]="autofocus"
     ></app-pure-pay-page>

--- a/web-client/src/app/views/pay/pay.page.ts
+++ b/web-client/src/app/views/pay/pay.page.ts
@@ -4,7 +4,9 @@ import { filterNilValue } from '@datorama/akita';
 import { LoadingController, NavController } from '@ionic/angular';
 import { Observable, pluck } from 'rxjs';
 import { Payment } from 'src/app/components/pay/pay.component';
+import { TransactionConfirmation } from 'src/app/services/algosdk.utils';
 import { SessionAlgorandService } from 'src/app/state/session-algorand.service';
+import { SessionXrplService } from 'src/app/state/session-xrpl.service';
 import { SessionQuery } from 'src/app/state/session.query';
 import { isAssetAmountAlgo } from 'src/app/utils/assets/assets.algo';
 import {
@@ -16,10 +18,20 @@ import {
   formatAssetAmount,
   formatAssetSymbol,
 } from 'src/app/utils/assets/assets.common';
+import {
+  convertFromAssetAmountXrpToLedger,
+  isAssetAmountXrp,
+} from 'src/app/utils/assets/assets.xrp';
+import {
+  convertFromAssetAmountXrplTokenToLedger,
+  isAssetAmountXrplToken,
+} from 'src/app/utils/assets/assets.xrp.token';
 import { panic } from 'src/app/utils/errors/panic';
 import { withLoadingOverlayOpts } from 'src/app/utils/loading.helpers';
 import { SwalHelper } from 'src/app/utils/notification/swal-helper';
 import { environment } from 'src/environments/environment';
+import { never } from 'src/helpers/helpers';
+import { TxResponse } from 'xrpl';
 
 @Component({
   selector: 'app-pay-page',
@@ -42,10 +54,14 @@ export class PayPage implements OnInit {
   algorandBalances: Observable<AssetAmount[]> =
     this.sessionQuery.algorandBalances;
 
+  xrplBalances: Observable<AssetAmount[] | undefined> =
+    this.sessionQuery.xrplBalances;
+
   constructor(
     private route: ActivatedRoute,
     private navCtrl: NavController,
     private sessionAlgorandService: SessionAlgorandService,
+    private sessionXrplService: SessionXrplService,
     public sessionQuery: SessionQuery,
     private loadingCtrl: LoadingController,
     private notification: SwalHelper
@@ -57,46 +73,110 @@ export class PayPage implements OnInit {
     amount,
     option: { receiverAddress },
   }: Payment): Promise<void> {
-    const confirmation = await withLoadingOverlayOpts(
+    const result = await withLoadingOverlayOpts(
       this.loadingCtrl,
       { message: 'Confirming Transaction' },
-      () => {
-        if (isAssetAmountAlgo(amount)) {
-          return this.sessionAlgorandService.sendAlgos(
-            receiverAddress,
-            amount.amount
-          );
-        } else if (isAssetAmountAsa(amount)) {
-          const { amount: amountInLedgerUnits, assetId } =
-            convertFromAssetAmountAsaToLedger(amount);
-          return this.sessionAlgorandService.sendAssetFunds(
-            assetId,
-            receiverAddress,
-            amountInLedgerUnits
-          );
-        } else {
-          throw panic('PayPage.onPaymentSubmitted: unexpected amount', {
-            amount,
-          });
-        }
-      }
+      () => this.sendByLedgerType(amount, receiverAddress)
     );
-    this.notifySuccess(
-      `${formatAssetAmount(amount)} ${formatAssetSymbol(amount)}`,
-      receiverAddress,
-      confirmation.txId,
-      new Date()
-    );
+    this.notifyResult(result, amount, receiverAddress);
   }
 
-  notifySuccess(
-    amount: string,
-    address: string,
-    txId: string,
-    timestamp: Date
-  ) {
-    const txIdHtml = environment.algorandTransactionUrlPrefix
-      ? `<a href="${environment.algorandTransactionUrlPrefix}${txId}" target="_blank" >${txId}</a>`
+  /**
+   * Send an amount to `receiverAddress` using the amount's ledger type and asset info.
+   *
+   * This currently handles:
+   *
+   * - Algorand: Algo & ASA
+   * - XRPL: XRP & tokens
+   *
+   * @todo Move this into an appropriate aggregated payment service somewhere?
+   */
+  protected async sendByLedgerType(
+    amount: AssetAmount,
+    receiverAddress: string
+  ): Promise<
+    { algorandResult: TransactionConfirmation } | { xrplResult: TxResponse }
+  > {
+    if (isAssetAmountAlgo(amount)) {
+      return {
+        algorandResult: await this.sessionAlgorandService.sendAlgos(
+          receiverAddress,
+          amount.amount
+        ),
+      };
+    } else if (isAssetAmountAsa(amount)) {
+      const { amount: amountInLedgerUnits, assetId } =
+        convertFromAssetAmountAsaToLedger(amount);
+      return {
+        algorandResult: await this.sessionAlgorandService.sendAssetFunds(
+          assetId,
+          receiverAddress,
+          amountInLedgerUnits
+        ),
+      };
+    } else if (isAssetAmountXrp(amount)) {
+      return {
+        xrplResult: await this.sessionXrplService.sendFunds(
+          receiverAddress,
+          convertFromAssetAmountXrpToLedger(amount)
+        ),
+      };
+    } else if (isAssetAmountXrplToken(amount)) {
+      return {
+        xrplResult: await this.sessionXrplService.sendFunds(
+          receiverAddress,
+          convertFromAssetAmountXrplTokenToLedger(amount)
+        ),
+      };
+    } else {
+      throw panic('PayPage.sendAmount: unexpected amount', { amount });
+    }
+  }
+
+  protected notifyResult(
+    result:
+      | { algorandResult: TransactionConfirmation }
+      | { xrplResult: TxResponse },
+    amount: AssetAmount,
+    receiverAddress: string
+  ): void {
+    if ('algorandResult' in result) {
+      const { algorandResult: confirmation } = result;
+      this.notifySuccess({
+        amount: `${formatAssetAmount(amount)} ${formatAssetSymbol(amount)}`,
+        address: receiverAddress,
+        txId: confirmation.txId,
+        timestamp: new Date(),
+        txUrlPrefix: environment.algorandTransactionUrlPrefix,
+      });
+    } else if ('xrplResult' in result) {
+      const { xrplResult: txResponse } = result;
+      this.notifySuccess({
+        amount: `${formatAssetAmount(amount)} ${formatAssetSymbol(amount)}`,
+        address: receiverAddress,
+        txId: txResponse.id.toString(),
+        timestamp: new Date(),
+      });
+    } else {
+      throw never(result);
+    }
+  }
+
+  protected notifySuccess({
+    amount,
+    address,
+    txId,
+    timestamp,
+    txUrlPrefix,
+  }: {
+    amount: string;
+    address: string;
+    txId: string;
+    timestamp: Date;
+    txUrlPrefix?: string;
+  }): void {
+    const txIdHtml = txUrlPrefix
+      ? `<a href="${txUrlPrefix}${txId}" target="_blank" >${txId}</a>`
       : `${txId}`;
     this.notification.swal
       .fire({

--- a/web-client/src/app/views/wallet/wallet.page.ts
+++ b/web-client/src/app/views/wallet/wallet.page.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { filterNilValue } from '@datorama/akita';
 import {
   faCreditCard,
   faDonate,
@@ -11,10 +10,8 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 import { LoadingController, ToastController } from '@ionic/angular';
 import { Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
 import { SessionAlgorandService } from 'src/app/state/session-algorand.service';
 import { SessionQuery } from 'src/app/state/session.query';
-import { assetAmountAlgo } from 'src/app/utils/assets/assets.algo';
 import { AssetAmount } from 'src/app/utils/assets/assets.common';
 import { defined } from 'src/app/utils/errors/panic';
 import { withLoadingOverlayOpts } from 'src/app/utils/loading.helpers';
@@ -66,11 +63,7 @@ export class WalletPage implements OnInit {
     },
   ]; // Placeholder icons until we get definite ones.
 
-  balances: Observable<Array<AssetAmount>> =
-    this.sessionQuery.algorandBalanceInAlgos.pipe(
-      filterNilValue(),
-      map((amount: number): AssetAmount[] => [assetAmountAlgo(amount)])
-    );
+  balances: Observable<AssetAmount[]> = this.sessionQuery.allBalances;
 
   constructor(
     private loadingController: LoadingController,

--- a/web-client/src/app/views/wallet/wallet.page.ts
+++ b/web-client/src/app/views/wallet/wallet.page.ts
@@ -11,6 +11,7 @@ import {
 import { LoadingController, ToastController } from '@ionic/angular';
 import { Observable } from 'rxjs';
 import { SessionAlgorandService } from 'src/app/state/session-algorand.service';
+import { SessionXrplService } from 'src/app/state/session-xrpl.service';
 import { SessionQuery } from 'src/app/state/session.query';
 import { AssetAmount } from 'src/app/utils/assets/assets.common';
 import { defined } from 'src/app/utils/errors/panic';
@@ -69,6 +70,7 @@ export class WalletPage implements OnInit {
     private loadingController: LoadingController,
     public sessionQuery: SessionQuery,
     public sessionAlgorandService: SessionAlgorandService,
+    public sessionXrplService: SessionXrplService,
     private toastCtrl: ToastController,
     private notification: SwalHelper
   ) {}
@@ -85,8 +87,13 @@ export class WalletPage implements OnInit {
       this.loadingController,
       { message: 'Refreshing…' },
       async () => {
-        await this.sessionAlgorandService.loadAccountData();
-        await this.sessionAlgorandService.loadAssetParams();
+        await Promise.all([
+          (async () => {
+            await this.sessionAlgorandService.loadAccountData();
+            await this.sessionAlgorandService.loadAssetParams();
+          })(),
+          this.sessionXrplService.loadAccountData(),
+        ]);
       }
     );
   }


### PR DESCRIPTION
Summary:

- `PayPage` (and components): Handle sending XRP & XRPL tokens.
- `WalletPage`: Show XRP & XRPL token balances.
- `xrpl.utils`: Add transaction status helpers.
- `console.helpers`: Helpers for more useful and readable console logging, especially of important API exchanges.

### Related

- Follows https://github.com/ntls-io/nautilus-wallet/pull/185