### PR TITLE
refactor(web-server): add unlock_wallet helper, with constant-time compare

### DIFF
--- a/web-server/sgx-wallet-impl/Cargo.lock
+++ b/web-server/sgx-wallet-impl/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sgx_tcrypto",
+ "sgx_trts",
  "sgx_tse",
  "sgx_tstd",
  "sgx_types",

--- a/web-server/sgx-wallet-impl/Cargo.toml
+++ b/web-server/sgx-wallet-impl/Cargo.toml
@@ -20,6 +20,7 @@ zeroize = { version = "1.5.3", features = ["alloc", "zeroize_derive"] }
 
 # SGX SDK
 sgx_tcrypto = { git = "https://github.com/apache/incubator-teaclave-sgx-sdk", rev = "e8a9fc22939befa27ff67f5509b2c2dfe8499945" }
+sgx_trts = { git = "https://github.com/apache/incubator-teaclave-sgx-sdk", rev = "e8a9fc22939befa27ff67f5509b2c2dfe8499945" }
 sgx_tse = { git = "https://github.com/apache/incubator-teaclave-sgx-sdk", rev = "e8a9fc22939befa27ff67f5509b2c2dfe8499945" }
 sgx_tstd = { git = "https://github.com/apache/incubator-teaclave-sgx-sdk", rev = "e8a9fc22939befa27ff67f5509b2c2dfe8499945" }
 sgx_types = { git = "https://github.com/apache/incubator-teaclave-sgx-sdk", rev = "e8a9fc22939befa27ff67f5509b2c2dfe8499945" }

--- a/web-server/sgx-wallet-impl/src/schema/actions.rs
+++ b/web-server/sgx-wallet-impl/src/schema/actions.rs
@@ -4,13 +4,14 @@
 //!
 //! * <https://developer.algorand.org/docs/reference/rest-apis/kmd/>
 
-use std::prelude::v1::String;
+use std::prelude::v1::{String, ToString};
 
 use serde::{Deserialize, Serialize};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::schema::entities::WalletDisplay;
 use crate::schema::types::{Bytes, WalletId, WalletPin};
+use crate::wallet_operations::store::UnlockWalletError;
 
 #[derive(Clone, Eq, PartialEq, Debug)] // core
 #[derive(Deserialize, Serialize)] // serde
@@ -43,6 +44,17 @@ pub enum OpenWalletResult {
     Failed(String),
 }
 
+impl From<UnlockWalletError> for OpenWalletResult {
+    fn from(err: UnlockWalletError) -> Self {
+        use UnlockWalletError::*;
+        match err {
+            InvalidWalletId => Self::InvalidAuth,
+            InvalidAuthPin => Self::InvalidAuth,
+            IoError(err) => Self::Failed(err.to_string()),
+        }
+    }
+}
+
 #[derive(Clone, Eq, PartialEq, Debug)] // core
 #[derive(Deserialize, Serialize)] // serde
 #[derive(Zeroize, ZeroizeOnDrop)] // zeroize
@@ -52,6 +64,17 @@ pub struct SignTransaction {
 
     #[zeroize(skip)]
     pub transaction_to_sign: TransactionToSign,
+}
+
+impl From<UnlockWalletError> for SignTransactionResult {
+    fn from(err: UnlockWalletError) -> Self {
+        use UnlockWalletError::*;
+        match err {
+            InvalidWalletId => Self::InvalidAuth,
+            InvalidAuthPin => Self::InvalidAuth,
+            IoError(err) => Self::Failed(err.to_string()),
+        }
+    }
 }
 
 /// For [`SignTransaction`]: A choice of type of transaction to sign.

--- a/web-server/sgx-wallet-impl/src/wallet_operations/open_wallet.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/open_wallet.rs
@@ -1,24 +1,12 @@
-use std::prelude::v1::ToString;
-
 use crate::schema::actions::{OpenWallet, OpenWalletResult};
 use crate::schema::entities::WalletDisplay;
-use crate::wallet_operations::store::load_wallet;
-
-type Result = OpenWalletResult;
+use crate::wallet_operations::store::unlock_wallet;
 
 pub fn open_wallet(request: &OpenWallet) -> OpenWalletResult {
-    let result = match load_wallet(&request.wallet_id) {
-        Ok(ok) => ok,
-        Err(err) => return Result::Failed(err.to_string()),
-    };
-    let stored = match result {
-        None => return Result::InvalidAuth,
-        Some(some) => some,
+    let stored = match unlock_wallet(&request.wallet_id, &request.auth_pin) {
+        Ok(stored) => stored,
+        Err(err) => return err.into(),
     };
 
-    if request.auth_pin == stored.auth_pin {
-        Result::Opened(WalletDisplay::from(stored))
-    } else {
-        Result::InvalidAuth
-    }
+    OpenWalletResult::Opened(WalletDisplay::from(stored))
 }

--- a/web-server/sgx-wallet-impl/src/wallet_operations/sign_transaction.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/sign_transaction.rs
@@ -1,6 +1,6 @@
 //! Implement [`SignTransaction`].
 
-use std::prelude::v1::{String, ToString};
+use std::prelude::v1::String;
 
 use crate::schema::actions::{
     SignTransaction,
@@ -10,25 +10,13 @@ use crate::schema::actions::{
 };
 use crate::wallet_operations::sign_transaction_algorand::sign_algorand;
 use crate::wallet_operations::sign_transaction_xrpl::sign_xrpl;
-use crate::wallet_operations::store::load_wallet;
+use crate::wallet_operations::store::unlock_wallet;
 
 pub fn sign_transaction(request: &SignTransaction) -> SignTransactionResult {
-    // Load identified wallet
-    let result = match load_wallet(&request.wallet_id) {
-        Ok(ok) => ok,
-        Err(err) => return SignTransactionResult::Failed(err.to_string()),
+    let stored = match unlock_wallet(&request.wallet_id, &request.auth_pin) {
+        Ok(stored) => stored,
+        Err(err) => return err.into(),
     };
-    let stored = match result {
-        None => return SignTransactionResult::InvalidAuth,
-        Some(some) => some,
-    };
-
-    // Verify request's authenticating PIN
-    if request.auth_pin != stored.auth_pin {
-        return SignTransactionResult::InvalidAuth;
-    }
-
-    // Authenticated! Proceed to sign the transaction.
 
     let sign_result: Result<TransactionSigned, String> = match &request.transaction_to_sign {
         TransactionToSign::AlgorandTransaction { transaction_bytes } => {

--- a/web-server/sgx-wallet-impl/src/wallet_operations/store.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/store.rs
@@ -1,6 +1,9 @@
 use std::io;
 use std::prelude::v1::Box;
 
+use sgx_trts::memeq::ConsttimeMemEq;
+use thiserror::Error;
+
 use crate::ported::kv_store::fs::{FsStore, SgxFiler};
 use crate::ported::kv_store::{Key, KvStore};
 use crate::schema::entities::WalletStorable;
@@ -26,6 +29,7 @@ pub fn save_new_wallet(new_wallet: &WalletStorable) -> Result<(), io::Error> {
     }
 }
 
+/// Return `None` if `wallet_id` not found.
 pub fn load_wallet(wallet_id: &str) -> Result<Option<WalletStorable>, io::Error> {
     let store = wallet_store();
     let key = &key_from_id(wallet_id)?;
@@ -44,4 +48,34 @@ pub fn key_from_id(wallet_id: &str) -> Result<Box<Key>, io::Error> {
         )
     })?;
     Ok(address.into())
+}
+
+/// Load and authenticate access to a wallet.
+pub fn unlock_wallet(wallet_id: &str, auth_pin: &str) -> Result<WalletStorable, UnlockWalletError> {
+    let stored: WalletStorable =
+        load_wallet(wallet_id)?.ok_or(UnlockWalletError::InvalidWalletId)?;
+
+    match ConsttimeMemEq::consttime_memeq(stored.auth_pin.as_bytes(), auth_pin.as_bytes()) {
+        true => Ok(stored),
+        false => Err(UnlockWalletError::InvalidAuthPin),
+    }
+}
+
+/// [`unlock_wallet`] failed.
+///
+/// # Security note
+///
+/// This representation distinguishes `InvalidWalletId` and `InvalidAuthPin`,
+/// but this distinction should be limited to internal interfaces:
+/// public interfaces should combine invalid authentication cases to avoid information leakage.
+#[derive(Debug, Error)]
+pub enum UnlockWalletError {
+    #[error("invalid wallet ID provided")]
+    InvalidWalletId,
+
+    #[error("invalid authentication PIN provided")]
+    InvalidAuthPin,
+
+    #[error("I/O error while opening wallet")]
+    IoError(#[from] io::Error),
 }

--- a/web-server/sgx-wallet-test/enclave/Cargo.lock
+++ b/web-server/sgx-wallet-test/enclave/Cargo.lock
@@ -807,6 +807,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sgx_tcrypto",
+ "sgx_trts",
  "sgx_tse",
  "sgx_tstd",
  "sgx_types",

--- a/web-server/sgx-wallet-test/enclave/src/lib.rs
+++ b/web-server/sgx-wallet-test/enclave/src/lib.rs
@@ -42,5 +42,9 @@ pub extern "C" fn run_tests_ecall() -> usize {
         wallet_operations::test_sign_transaction::sign_transaction_works,
         wallet_operations::test_sign_transaction_msgpack::prop_transaction_msgpack_roundtrips,
         wallet_operations::test_sign_transaction_xrpl::sign_transaction_empty,
+        wallet_operations::test_store::unlock_wallet_bad_auth_pin,
+        wallet_operations::test_store::unlock_wallet_malformed_wallet_id,
+        wallet_operations::test_store::unlock_wallet_not_found,
+        wallet_operations::test_store::unlock_wallet_works,
     )
 }

--- a/web-server/sgx-wallet-test/enclave/src/lib.rs
+++ b/web-server/sgx-wallet-test/enclave/src/lib.rs
@@ -40,7 +40,7 @@ pub extern "C" fn run_tests_ecall() -> usize {
         wallet_operations::test_sign_transaction::sign_transaction_malformed_transaction,
         wallet_operations::test_sign_transaction::sign_transaction_without_tag,
         wallet_operations::test_sign_transaction::sign_transaction_works,
-        wallet_operations::test_sign_transaction_xrpl::sign_transaction_empty,
         wallet_operations::test_sign_transaction_msgpack::prop_transaction_msgpack_roundtrips,
+        wallet_operations::test_sign_transaction_xrpl::sign_transaction_empty,
     )
 }

--- a/web-server/sgx-wallet-test/enclave/src/wallet_operations/mod.rs
+++ b/web-server/sgx-wallet-test/enclave/src/wallet_operations/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod test_open_wallet;
 pub(crate) mod test_sign_transaction;
 pub(crate) mod test_sign_transaction_msgpack;
 pub(crate) mod test_sign_transaction_xrpl;
+pub(crate) mod test_store;

--- a/web-server/sgx-wallet-test/enclave/src/wallet_operations/test_store.rs
+++ b/web-server/sgx-wallet-test/enclave/src/wallet_operations/test_store.rs
@@ -1,0 +1,37 @@
+//! Test [`sgx_wallet_impl::wallet_operations::store`]
+
+use std::prelude::v1::ToString;
+
+use sgx_wallet_impl::ported::kv_store::KvStore;
+use sgx_wallet_impl::schema::entities::WalletDisplay;
+use sgx_wallet_impl::wallet_operations::store::{key_from_id, unlock_wallet, wallet_store};
+
+use crate::helpers::wallet_store::create_test_wallet;
+
+pub(crate) fn unlock_wallet_works() {
+    let existing = create_test_wallet();
+    let stored = unlock_wallet(&existing.wallet_id, "123456").unwrap();
+    assert_eq!(existing, WalletDisplay::from(stored));
+}
+
+pub(crate) fn unlock_wallet_not_found() {
+    let existing = create_test_wallet();
+    let mut store = wallet_store();
+    let key = &key_from_id(&existing.wallet_id).unwrap();
+    store.delete(key).unwrap();
+
+    let err = unlock_wallet(&existing.wallet_id, "123456").unwrap_err();
+    assert_eq!(err.to_string(), "invalid wallet ID provided");
+}
+
+pub(crate) fn unlock_wallet_malformed_wallet_id() {
+    create_test_wallet();
+    let err = unlock_wallet("malformed", "123456").unwrap_err();
+    assert_eq!(err.to_string(), "I/O error while opening wallet");
+}
+
+pub(crate) fn unlock_wallet_bad_auth_pin() {
+    let existing = create_test_wallet();
+    let err = unlock_wallet(&existing.wallet_id, "000000").unwrap_err();
+    assert_eq!(err.to_string(), "invalid authentication PIN provided");
+}

--- a/web-server/sgx-wallet/enclave/Cargo.lock
+++ b/web-server/sgx-wallet/enclave/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sgx_tcrypto",
+ "sgx_trts",
  "sgx_tse",
  "sgx_tstd",
  "sgx_types",


### PR DESCRIPTION
- Add `sgx_trts` dependency
- Factor out common `unlock_wallet` helper from `open_wallet` and `sign_transaction`
- Replace PIN comparison with [ConsttimeMemEq]

[ConsttimeMemEq]: https://dingelish.github.io/sgx_trts/sgx_trts/memeq/trait.ConsttimeMemEq.html

### Related

- Precedes https://github.com/ntls-io/nautilus-wallet/pull/189