### PR TITLE
feat(web-client,KycPage): use Onfido check storage

### DIFF
--- a/web-client/src/app/services/enclave/enclave.service.ts
+++ b/web-client/src/app/services/enclave/enclave.service.ts
@@ -1,6 +1,7 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { lastValueFrom } from 'rxjs';
+import { withLoggedExchange } from 'src/app/utils/console.helpers';
 import { environment } from 'src/environments/environment';
 import {
   CreateWallet,
@@ -122,6 +123,16 @@ export class EnclaveService {
   }
 
   protected async postSealedExchange<Request, Response>(
+    request: Request
+  ): Promise<Response> {
+    return withLoggedExchange(
+      'EnclaveService.postSealedExchange:',
+      () => this.postSealedExchangeInner(request),
+      request
+    );
+  }
+
+  protected async postSealedExchangeInner<Request, Response>(
     request: Request
   ): Promise<Response> {
     const clientCrypto = TweetNaClCrypto.new();

--- a/web-client/src/app/services/enclave/enclave.service.ts
+++ b/web-client/src/app/services/enclave/enclave.service.ts
@@ -5,8 +5,12 @@ import { environment } from 'src/environments/environment';
 import {
   CreateWallet,
   CreateWalletResult,
+  LoadOnfidoCheck,
+  LoadOnfidoCheckResult,
   OpenWallet,
   OpenWalletResult,
+  SaveOnfidoCheck,
+  SaveOnfidoCheckResult,
   SignTransaction,
   SignTransactionResult,
 } from 'src/schema/actions';
@@ -64,6 +68,30 @@ export class EnclaveService {
       { SignTransaction: SignTransactionResult }
     >(walletRequest);
     const { SignTransaction: result } = response;
+    return result;
+  }
+
+  async saveOnfidoCheck(
+    request: SaveOnfidoCheck
+  ): Promise<SaveOnfidoCheckResult> {
+    const walletRequest = { SaveOnfidoCheck: request };
+    const response = await this.postSealedExchange<
+      { SaveOnfidoCheck: SaveOnfidoCheck },
+      { SaveOnfidoCheck: SaveOnfidoCheckResult }
+    >(walletRequest);
+    const { SaveOnfidoCheck: result } = response;
+    return result;
+  }
+
+  async loadOnfidoCheck(
+    request: LoadOnfidoCheck
+  ): Promise<LoadOnfidoCheckResult> {
+    const walletRequest = { LoadOnfidoCheck: request };
+    const response = await this.postSealedExchange<
+      { LoadOnfidoCheck: LoadOnfidoCheck },
+      { LoadOnfidoCheck: LoadOnfidoCheckResult }
+    >(walletRequest);
+    const { LoadOnfidoCheck: result } = response;
     return result;
   }
 

--- a/web-client/src/app/state/session.query.spec.ts
+++ b/web-client/src/app/state/session.query.spec.ts
@@ -76,6 +76,11 @@ describe('SessionQuery', () => {
         { value: '1', currency: 'XRP' },
         { value: '1', currency: 'PCT', issuer: 'PCT issuer' },
       ],
+      onfidoCheck: {
+        id: 'uuid',
+        href: 'https://dashboard.onfido.com/checks/uuid',
+        result: 'clear',
+      },
     };
     store.update(state);
     return state;
@@ -103,6 +108,11 @@ describe('SessionQuery', () => {
       expect(await get(query.algorandAccountData)).toEqual(
         stub.algorandAccountData
       );
+    });
+    it('onfidoCheck', async () => {
+      expect(await get(query.onfidoCheck)).toBeUndefined();
+      const stub = stubState();
+      expect(await get(query.onfidoCheck)).toEqual(stub.onfidoCheck);
     });
   });
 

--- a/web-client/src/app/state/session.query.spec.ts
+++ b/web-client/src/app/state/session.query.spec.ts
@@ -41,7 +41,7 @@ describe('SessionQuery', () => {
   type StubSessionState = SessionState &
     Pick<
       Required<SessionState>,
-      'wallet' | 'pin' | 'algorandAccountData' | 'xrplBalances'
+      'wallet' | 'pin' | 'algorandAccountData' | 'xrplBalances' | 'onfidoCheck'
     >;
 
   const stubState = (): StubSessionState => {
@@ -109,10 +109,38 @@ describe('SessionQuery', () => {
         stub.algorandAccountData
       );
     });
+
     it('onfidoCheck', async () => {
       expect(await get(query.onfidoCheck)).toBeUndefined();
       const stub = stubState();
       expect(await get(query.onfidoCheck)).toEqual(stub.onfidoCheck);
+    });
+
+    describe('onfidoCheckIsClear', () => {
+      it('when clear', async () => {
+        stubState();
+        expect(await get(query.onfidoCheckIsClear)).toBeTrue();
+      });
+
+      it('not when missing', async () => {
+        expect(await get(query.onfidoCheckIsClear)).toBeFalse();
+      });
+
+      it('not when consider', async () => {
+        const stub = stubState();
+        store.update({
+          onfidoCheck: { ...stub.onfidoCheck, result: 'consider' },
+        });
+        expect(await get(query.onfidoCheckIsClear)).toBeFalse();
+      });
+
+      it('not when unidentified', async () => {
+        const stub = stubState();
+        store.update({
+          onfidoCheck: { ...stub.onfidoCheck, result: 'unidentified' },
+        });
+        expect(await get(query.onfidoCheckIsClear)).toBeFalse();
+      });
     });
   });
 

--- a/web-client/src/app/state/session.query.ts
+++ b/web-client/src/app/state/session.query.ts
@@ -138,6 +138,9 @@ export class SessionQuery extends Query<SessionState> {
     distinctUntilChanged()
   );
 
+  onfidoCheck: Observable<SessionState['onfidoCheck']> =
+    this.select('onfidoCheck');
+
   constructor(protected store: SessionStore) {
     super(store);
   }

--- a/web-client/src/app/state/session.query.ts
+++ b/web-client/src/app/state/session.query.ts
@@ -16,6 +16,7 @@ import { assetAmountXrplToken } from 'src/app/utils/assets/assets.xrp.token';
 import { defined } from 'src/app/utils/errors/panic';
 import { parseNumber } from 'src/app/utils/validators';
 import { allDefinedOrNone, ifDefined } from 'src/helpers/helpers';
+import { OnfidoCheckResult } from 'src/schema/actions';
 import { WalletDisplay } from 'src/schema/entities';
 import { SessionState, SessionStore } from './session.store';
 
@@ -140,6 +141,10 @@ export class SessionQuery extends Query<SessionState> {
 
   onfidoCheck: Observable<SessionState['onfidoCheck']> =
     this.select('onfidoCheck');
+
+  onfidoCheckIsClear: Observable<boolean> = this.onfidoCheck.pipe(
+    map((onfidoCheck?: OnfidoCheckResult) => onfidoCheck?.result === 'clear')
+  );
 
   constructor(protected store: SessionStore) {
     super(store);

--- a/web-client/src/app/state/session.service.ts
+++ b/web-client/src/app/state/session.service.ts
@@ -50,7 +50,7 @@ export class SessionService {
         this.sessionStore.setError(result);
         throw panic('SessionService: createWallet failed', result);
       } else {
-        never(result);
+        throw never(result);
       }
     } catch (err) {
       this.sessionStore.setError(err);
@@ -82,7 +82,7 @@ export class SessionService {
       console.error(result);
       throw new Error(result.Failed);
     } else {
-      never(result);
+      throw never(result);
     }
   }
 

--- a/web-client/src/app/state/session.service.ts
+++ b/web-client/src/app/state/session.service.ts
@@ -7,8 +7,13 @@ import { never } from 'src/helpers/helpers';
 import {
   CreateWallet,
   CreateWalletResult,
+  LoadOnfidoCheck,
+  LoadOnfidoCheckResult,
+  OnfidoCheckResult,
   OpenWallet,
   OpenWalletResult,
+  SaveOnfidoCheck,
+  SaveOnfidoCheckResult,
   SignTransaction,
   SignTransactionResult,
   TransactionSigned,
@@ -118,6 +123,71 @@ export class SessionService {
       );
     } else {
       throw never(signResult);
+    }
+  }
+
+  /**
+   * Save the given Onfido check result to the active session's wallet.
+   *
+   * @see EnclaveService#saveOnfidoCheck
+   */
+  async saveOnfidoCheck(check: OnfidoCheckResult): Promise<void> {
+    const { wallet, pin } = this.sessionQuery.assumeActiveSession();
+
+    const request: SaveOnfidoCheck = {
+      wallet_id: wallet.wallet_id,
+      auth_pin: pin,
+      check,
+    };
+    const result: SaveOnfidoCheckResult =
+      await this.enclaveService.saveOnfidoCheck(request);
+
+    if ('Saved' in result) {
+      // XXX(Pi): It might be better to explicitly load this back,
+      //          rather than optimistically persisting like this?
+      this.sessionStore.update({ onfidoCheck: check });
+      return;
+    } else if ('InvalidAuth' in result) {
+      throw panic('TODO', result);
+    } else if ('Failed' in result) {
+      console.error(result);
+      throw new Error(result.Failed);
+    } else {
+      throw never(result);
+    }
+  }
+
+  /**
+   * Load the saved Onfido check result for the active session's wallet, if any.
+   *
+   * @see EnclaveService#loadOnfidoCheck
+   */
+  async loadOnfidoCheck(): Promise<OnfidoCheckResult | undefined> {
+    const { wallet, pin } = this.sessionQuery.assumeActiveSession();
+
+    const request: LoadOnfidoCheck = {
+      wallet_id: wallet.wallet_id,
+      auth_pin: pin,
+    };
+    const result: LoadOnfidoCheckResult =
+      await this.enclaveService.loadOnfidoCheck(request);
+
+    if ('Loaded' in result) {
+      const onfidoCheck: OnfidoCheckResult = result.Loaded;
+      this.sessionStore.update({ onfidoCheck });
+      return onfidoCheck;
+    } else if ('NotFound' in result) {
+      return undefined;
+    } else if ('InvalidAuth' in result) {
+      // TODO: Better error representation.
+      throw new Error(
+        'Authentication failed, please ensure that the address and password provided is correct.'
+      );
+    } else if ('Failed' in result) {
+      console.error(result);
+      throw new Error(result.Failed);
+    } else {
+      throw never(result);
     }
   }
 }

--- a/web-client/src/app/state/session.store.ts
+++ b/web-client/src/app/state/session.store.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { Store, StoreConfig } from '@datorama/akita';
 import { AccountData, AssetParams } from 'src/app/services/algosdk.utils';
+import { OnfidoCheckResult } from 'src/schema/actions';
 import { WalletDisplay } from 'src/schema/entities';
 import * as xrpl from 'xrpl';
 
@@ -52,6 +53,8 @@ export interface SessionState {
    * @see https://js.xrpl.org/classes/Client.html#getBalances
    */
   xrplBalances?: XrplBalance[];
+
+  onfidoCheck?: OnfidoCheckResult;
 }
 
 export type XrplBalance = {

--- a/web-client/src/app/views/kyc/kyc.page.html
+++ b/web-client/src/app/views/kyc/kyc.page.html
@@ -15,31 +15,61 @@
       (completed)="onSdkComplete($event)"
     ></app-onfido-widget>
 
-    <div *ngIf="viewState === 'step3_result'">
-      <ion-card>
-        <ion-card-header>
-          <ion-card-title>Check result</ion-card-title>
-        </ion-card-header>
+    <div *ngIf="viewState === 'step3_result'" class="text-center">
+      <h1 class="text-center font-nasalization">
+        Verifying Identity<ng-container *ngIf="!checkIsComplete"
+          >…</ng-container
+        >
+      </h1>
 
-        <ion-card-content>
-          <table class="check-result">
-            <tr>
-              <th>Created at:</th>
-              <td [innerText]="check?.created_at"></td>
-            </tr>
-            <tr>
-              <th>Status:</th>
-              <td [innerText]="check?.status"></td>
-            </tr>
-            <tr>
-              <th>Result:</th>
-              <td [innerText]="check?.result"></td>
-            </tr>
-          </table>
+      <div>
+        <table class="inline-table check-result">
+          <tr>
+            <th>Check created:</th>
+            <td [innerText]="check?.created_at"></td>
+          </tr>
+          <tr>
+            <th>Status:</th>
+            <td
+              [innerText]="check?.status?.replace?.('_', ' ') | titlecase "
+            ></td>
+          </tr>
+          <tr *ngIf="check?.result">
+            <th>Result:</th>
+            <td
+              class="font-bold text-lg"
+              [innerText]="check?.result?.replace?.('_', ' ') | titlecase"
+            ></td>
+          </tr>
+        </table>
+      </div>
 
-          <ion-button (click)="refreshCheck()">Refresh</ion-button>
-        </ion-card-content>
-      </ion-card>
+      <div>
+        <ion-button
+          *ngIf="!checkIsComplete"
+          (click)="refreshCheck()"
+          shape="round"
+          class="ion-margin"
+          >Refresh</ion-button
+        >
+        <ion-button
+          *ngIf="checkIsComplete && checkIsClear"
+          (click)="saveCheck()"
+          color="success"
+          shape="round"
+          class="ion-margin"
+          >Save</ion-button
+        >
+        <ion-button
+          routerLink="/wallet"
+          routerDirection="root"
+          color="medium"
+          fill="outline"
+          shape="round"
+          class="ion-margin"
+          >Cancel</ion-button
+        >
+      </div>
     </div>
   </ion-grid>
 </ion-content>

--- a/web-client/src/app/views/kyc/kyc.page.scss
+++ b/web-client/src/app/views/kyc/kyc.page.scss
@@ -1,8 +1,13 @@
 table.check-result {
   border-collapse: separate;
-  border-spacing: 1em;
+  border-spacing: 1em 0.5em;
 
   th {
     text-align: right;
+    font-weight: normal;
+    opacity: 0.5;
+  }
+  td {
+    text-align: left;
   }
 }

--- a/web-client/src/app/views/kyc/kyc.page.spec.ts
+++ b/web-client/src/app/views/kyc/kyc.page.spec.ts
@@ -1,5 +1,6 @@
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
 import { IonicModule } from '@ionic/angular';
 import { SdkResponse } from 'onfido-sdk-ui';
 import {
@@ -21,7 +22,11 @@ describe('KycPage', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [KycPage],
-        imports: [IonicModule.forRoot(), HttpClientTestingModule],
+        imports: [
+          IonicModule.forRoot(),
+          RouterTestingModule,
+          HttpClientTestingModule,
+        ],
       }).compileComponents();
 
       onfidoService = TestBed.inject(OnfidoService);
@@ -62,6 +67,12 @@ describe('KycPage', () => {
   });
 
   it('onSdkComplete + createCheck', async () => {
+    // Stub refreshCheck
+    const refreshCheckSpy: Spy<typeof component.refreshCheck> = spyOn(
+      component,
+      'refreshCheck'
+    ).and.resolveTo();
+
     const sdkResponse: SdkResponse = {};
 
     const check: Check = { id: 'placeholder id' };
@@ -79,6 +90,8 @@ describe('KycPage', () => {
     );
     expect(component.check).toBe(check);
     expect(component.viewState).toBe('step3_result');
+
+    expect(refreshCheckSpy).toHaveBeenCalledOnceWith();
   });
 
   it('refreshCheck', async () => {

--- a/web-client/src/app/views/kyc/kyc.page.stories.ts
+++ b/web-client/src/app/views/kyc/kyc.page.stories.ts
@@ -31,43 +31,46 @@ Step2_Widget.args = {
   token: OnfidoWidgetComponentStories.Default.args?.token,
 };
 
+const exampleCheck = {
+  id: '111111111-1111-1111-1111-111111111111',
+  created_at: '2021-10-12T17:39:22Z',
+  href: '/v3.2/checks/111111111-1111-1111-1111-111111111111',
+  results_uri:
+    'https://dashboard.onfido.com/checks/111111111-1111-1111-1111-111111111111',
+  applicant_id: '000000000-0000-0000-0000-000000000000',
+  tags: [],
+  applicant_provides_data: false,
+  report_ids: [
+    '222222222-2222-2222-2222-222222222222',
+    '333333333-3333-3333-3333-333333333333',
+  ],
+};
+
 export const Step3_CheckInProgress = Template.bind({});
 Step3_CheckInProgress.args = {
   viewState: 'step3_result',
   check: {
-    id: '111111111-1111-1111-1111-111111111111',
-    created_at: '2021-10-12T17:39:22Z',
-    href: '/v3.2/checks/111111111-1111-1111-1111-111111111111',
+    ...exampleCheck,
     status: 'in_progress',
-    results_uri:
-      'https://dashboard.onfido.com/checks/111111111-1111-1111-1111-111111111111',
-    applicant_id: '000000000-0000-0000-0000-000000000000',
-    tags: [],
-    applicant_provides_data: false,
-    report_ids: [
-      '222222222-2222-2222-2222-222222222222',
-      '333333333-3333-3333-3333-333333333333',
-    ],
   },
 };
 
-export const Step3_CheckComplete = Template.bind({});
-Step3_CheckComplete.args = {
+export const Step3_CheckClear = Template.bind({});
+Step3_CheckClear.args = {
   viewState: 'step3_result',
   check: {
-    id: '111111111-1111-1111-1111-111111111111',
-    created_at: '2021-10-12T17:39:22Z',
-    href: '/v3.2/checks/111111111-1111-1111-1111-111111111111',
+    ...exampleCheck,
     status: 'complete',
     result: 'clear',
-    results_uri:
-      'https://dashboard.onfido.com/checks/111111111-1111-1111-1111-111111111111',
-    applicant_id: '000000000-0000-0000-0000-000000000000',
-    tags: [],
-    applicant_provides_data: false,
-    report_ids: [
-      '222222222-2222-2222-2222-222222222222',
-      '333333333-3333-3333-3333-333333333333',
-    ],
+  },
+};
+
+export const Step3_CheckNotClear = Template.bind({});
+Step3_CheckNotClear.args = {
+  viewState: 'step3_result',
+  check: {
+    ...exampleCheck,
+    status: 'complete',
+    result: 'unidentified',
   },
 };

--- a/web-client/src/schema/actions.ts
+++ b/web-client/src/schema/actions.ts
@@ -55,14 +55,56 @@ export type TransactionSigned =
       };
     };
 
+export type SaveOnfidoCheck = {
+  wallet_id: WalletId;
+  auth_pin: WalletPin;
+
+  check: OnfidoCheckResult;
+};
+
+export type SaveOnfidoCheckResult =
+  | { Saved: null }
+  | { InvalidAuth: null }
+  | { Failed: string };
+
+export type LoadOnfidoCheck = {
+  wallet_id: WalletId;
+  auth_pin: WalletPin;
+};
+
+export type LoadOnfidoCheckResult =
+  | { Loaded: OnfidoCheckResult }
+  | { NotFound: null }
+  | { InvalidAuth: null }
+  | { Failed: string };
+
+/**
+ * @see import('src/app/services/onfido.service.ts').Check
+ */
+export type OnfidoCheckResult = {
+  id: string;
+
+  href: string;
+
+  // Docs: <https://documentation.onfido.com/v2/#report-results>
+  result: string;
+
+  // Docs: <https://documentation.onfido.com/v2/#sub-results-document-reports>
+  sub_result?: string;
+};
+
 /** Dispatching enum for action requests. */
 export type WalletRequest =
   | { CreateWallet: CreateWallet }
   | { OpenWallet: OpenWallet }
-  | { SignTransaction: SignTransaction };
+  | { SignTransaction: SignTransaction }
+  | { SaveOnfidoCheck: SaveOnfidoCheck }
+  | { LoadOnfidoCheck: LoadOnfidoCheck };
 
 /** Dispatching enum for action results. */
 export type WalletResponse =
   | { CreateWallet: CreateWalletResult }
   | { OpenWallet: OpenWalletResult }
-  | { SignTransaction: SignTransactionResult };
+  | { SignTransaction: SignTransactionResult }
+  | { SaveOnfidoCheck: SaveOnfidoCheckResult }
+  | { LoadOnfidoCheck: LoadOnfidoCheckResult };


### PR DESCRIPTION
Summary:

- Add client-side support for Onfido check storage: https://github.com/ntls-io/nautilus-wallet/pull/189
- Improve `KycPage` UI/UX, and allow saving successful results.

### Related

- Follows https://github.com/ntls-io/nautilus-wallet/pull/191
- Precedes https://github.com/ntls-io/nautilus-wallet/pull/194