### PR TITLE
feat(web-client): add opportunistic XRPL token opt-ins

### DIFF
--- a/web-client/src/app/services/xrpl.service.ts
+++ b/web-client/src/app/services/xrpl.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { defined } from 'src/app/utils/errors/panic';
 import { environment } from 'src/environments/environment';
 import * as xrpl from 'xrpl';
+import { IssuedCurrencyAmount } from 'xrpl/dist/npm/models/common/index';
 
 /**
  * This service wraps an instance of the algosdk {@link xrpl.Client},
@@ -100,6 +101,20 @@ export class XrplService {
       TransactionType: 'Payment',
       Amount: amount,
       Destination: toAddress,
+    };
+    return await this.withConnection(
+      async (client) => await client.autofill(unpreparedTx)
+    );
+  }
+
+  async createUnsignedTrustSetTx(
+    fromAddress: string,
+    limitAmount: IssuedCurrencyAmount
+  ): Promise<xrpl.TrustSet> {
+    const unpreparedTx: xrpl.TrustSet = {
+      Account: fromAddress,
+      TransactionType: 'TrustSet',
+      LimitAmount: limitAmount,
     };
     return await this.withConnection(
       async (client) => await client.autofill(unpreparedTx)

--- a/web-client/src/app/services/xrpl.service.ts
+++ b/web-client/src/app/services/xrpl.service.ts
@@ -58,6 +58,28 @@ export class XrplService {
   }
 
   /**
+   * Retrieve information about an account's trust lines.
+   *
+   * This call defaults to:
+   *
+   * - `ledger_index: 'validated'`
+   *
+   * @see https://xrpl.org/account_lines.html
+   */
+  async getAccountLines(
+    request: Omit<xrpl.AccountLinesRequest, 'command'>
+  ): Promise<xrpl.AccountLinesResponse> {
+    return await this.withConnection(
+      async (client) =>
+        await client.request({
+          ledger_index: 'validated',
+          ...request,
+          command: 'account_lines',
+        })
+    );
+  }
+
+  /**
    * Wrap {@link xrpl.Client.getBalances}.
    *
    * @see https://js.xrpl.org/classes/Client.html#getBalances

--- a/web-client/src/app/state/session-xrpl.service.ts
+++ b/web-client/src/app/state/session-xrpl.service.ts
@@ -12,6 +12,7 @@ import { withLoggedExchange } from 'src/app/utils/console.helpers';
 import { panic } from 'src/app/utils/errors/panic';
 import { TransactionSigned, TransactionToSign } from 'src/schema/actions';
 import * as xrpl from 'xrpl';
+import { Trustline } from 'xrpl/dist/npm/models/methods/accountLines';
 import { SessionQuery } from './session.query';
 import { SessionStore, XrplBalance } from './session.store';
 
@@ -49,12 +50,18 @@ export class SessionXrplService {
     const xrplAccountRoot: xrpl.LedgerEntry.AccountRoot =
       accountInfo.result.account_data;
 
+    // Get account's trust lines:
+    const accountLines = await this.xrplService.getAccountLines({
+      account: xrplAddress,
+    });
+    const xrplTrustlines: Trustline[] = accountLines.result.lines;
+
     // Get balances:
     const xrplBalances: XrplBalance[] = await this.xrplService.getBalances(
       xrplAddress
     );
 
-    this.sessionStore.update({ xrplAccountRoot, xrplBalances });
+    this.sessionStore.update({ xrplAccountRoot, xrplTrustlines, xrplBalances });
   }
 
   async sendFunds(

--- a/web-client/src/app/state/session.query.spec.ts
+++ b/web-client/src/app/state/session.query.spec.ts
@@ -19,8 +19,10 @@ import {
   AssetAmountXrplToken,
   assetAmountXrplToken,
 } from 'src/app/utils/assets/assets.xrp.token';
+import { parseNumber } from 'src/app/utils/validators';
 import { WalletDisplay } from 'src/schema/entities';
 import { stubActiveSession } from 'src/tests/state.helpers';
+import * as xrpl from 'xrpl';
 import { SessionQuery } from './session.query';
 import { SessionState, SessionStore } from './session.store';
 
@@ -41,7 +43,12 @@ describe('SessionQuery', () => {
   type StubSessionState = SessionState &
     Pick<
       Required<SessionState>,
-      'wallet' | 'pin' | 'algorandAccountData' | 'xrplBalances' | 'onfidoCheck'
+      | 'wallet'
+      | 'pin'
+      | 'algorandAccountData'
+      | 'xrplAccountRoot'
+      | 'xrplBalances'
+      | 'onfidoCheck'
     >;
 
   const stubState = (): StubSessionState => {
@@ -72,6 +79,9 @@ describe('SessionQuery', () => {
           total: 10_000,
         },
       },
+      xrplAccountRoot: {
+        Balance: xrpl.xrpToDrops('1'),
+      } as xrpl.LedgerEntry.AccountRoot, // XXX: Stub a partial record, for now.
       xrplBalances: [
         { value: '1', currency: 'XRP' },
         { value: '1', currency: 'PCT', issuer: 'PCT issuer' },
@@ -263,6 +273,20 @@ describe('SessionQuery', () => {
       expect(query.hasAlgorandBalance()).toBeFalse();
       stubState();
       expect(query.hasAlgorandBalance()).toBeTrue();
+    });
+
+    it('getXrpBalanceInDrops', () => {
+      expect(query.getXrpBalanceInDrops()).toBeUndefined();
+      const stub = stubState();
+      expect(query.getXrpBalanceInDrops()).toBe(
+        parseNumber(stub.xrplAccountRoot.Balance)
+      );
+    });
+
+    it('hasXrpBalance', () => {
+      expect(query.hasXrpBalance()).toBeFalse();
+      stubState();
+      expect(query.hasXrpBalance()).toBeTrue();
     });
   });
 

--- a/web-client/src/app/state/session.query.spec.ts
+++ b/web-client/src/app/state/session.query.spec.ts
@@ -120,6 +120,18 @@ describe('SessionQuery', () => {
       );
     });
 
+    it('xrplAccountRoot', async () => {
+      expect(await get(query.xrplAccountRoot)).toBeUndefined();
+      const stub = stubState();
+      expect(await get(query.xrplAccountRoot)).toEqual(stub.xrplAccountRoot);
+    });
+
+    it('xrplTrustLines', async () => {
+      expect(await get(query.xrplTrustlines)).toBeUndefined();
+      const stub = stubState();
+      expect(await get(query.xrplTrustlines)).toEqual(stub.xrplTrustlines);
+    });
+
     it('onfidoCheck', async () => {
       expect(await get(query.onfidoCheck)).toBeUndefined();
       const stub = stubState();

--- a/web-client/src/app/state/session.query.ts
+++ b/web-client/src/app/state/session.query.ts
@@ -171,6 +171,14 @@ export class SessionQuery extends Query<SessionState> {
     return 0 < (this.getAlgorandBalanceInMicroAlgos() ?? 0);
   }
 
+  getXrpBalanceInDrops(): number | undefined {
+    return ifDefined(this.getValue().xrplAccountRoot?.Balance, parseNumber);
+  }
+
+  hasXrpBalance() {
+    return 0 < (this.getXrpBalanceInDrops() ?? 0);
+  }
+
   /**
    * Get the current Algorand account's balance for the given ASA.
    *

--- a/web-client/src/app/state/session.query.ts
+++ b/web-client/src/app/state/session.query.ts
@@ -27,8 +27,15 @@ import { SessionState, SessionStore } from './session.store';
 export class SessionQuery extends Query<SessionState> {
   wallet: Observable<SessionState['wallet']> = this.select('wallet');
   pin: Observable<SessionState['pin']> = this.select('pin');
+
   algorandAccountData: Observable<SessionState['algorandAccountData']> =
     this.select('algorandAccountData');
+
+  xrplAccountRoot: Observable<SessionState['xrplAccountRoot']> =
+    this.select('xrplAccountRoot');
+
+  xrplTrustlines: Observable<SessionState['xrplTrustlines']> =
+    this.select('xrplTrustlines');
 
   // Wallet field queries:
 

--- a/web-client/src/app/state/session.store.ts
+++ b/web-client/src/app/state/session.store.ts
@@ -4,6 +4,7 @@ import { AccountData, AssetParams } from 'src/app/services/algosdk.utils';
 import { OnfidoCheckResult } from 'src/schema/actions';
 import { WalletDisplay } from 'src/schema/entities';
 import * as xrpl from 'xrpl';
+import { Trustline } from 'xrpl/dist/npm/models/methods/accountLines';
 
 /**
  * State stored for a user session.
@@ -45,6 +46,15 @@ export interface SessionState {
    * @see https://js.xrpl.org/interfaces/LedgerEntry.AccountRoot.html
    */
   xrplAccountRoot?: xrpl.LedgerEntry.AccountRoot;
+
+  /**
+   * The current session's XRPL trust lines.
+   *
+   * @see import('./session-xrpl.service').SessionXrplService
+   * @see https://xrpl.org/account_lines.html#response-format
+   * @see https://js.xrpl.org/interfaces/AccountLinesResponse.html#result
+   */
+  xrplTrustlines?: Trustline[];
 
   /**
    * The current session's XRPL balances.


### PR DESCRIPTION
This performs opportunistic XRPL token opt-in to any peer trustlines on wallet open (similar to the Algorand ASA opt-in).

This needs more proper UI at some point, but this is a minimal foundation to enable basic XRPL token transacting.
