### PR TITLE
feat(web-client): handle XRPL `actNotFound`

### DIFF
--- a/web-client/src/app/services/xrpl.utils.spec.ts
+++ b/web-client/src/app/services/xrpl.utils.spec.ts
@@ -1,5 +1,6 @@
 import * as xrpl from 'xrpl';
 import {
+  checkRippledErrorResponse,
   hexToUint8Array,
   txnAfterSign,
   txnBeforeSign,
@@ -70,5 +71,37 @@ describe('uint8ArrayToHex', () => {
     expect(uint8ArrayToHex(new Uint8Array([0xab, 0xcd, 0xef]))).toEqual(
       'ABCDEF'
     );
+  });
+});
+
+describe('checkRippledErrorResponse', () => {
+  const exampleErrorResponse: xrpl.ErrorResponse = {
+    id: 'stub id',
+    status: 'error',
+    type: 'response',
+    error: 'stub error',
+    request: {
+      command: 'ping',
+    },
+  };
+
+  it('works', () => {
+    const err = new xrpl.RippledError('error message', exampleErrorResponse);
+    expect(checkRippledErrorResponse(err)).toEqual(exampleErrorResponse);
+  });
+
+  it('ignores RippledError without data', () => {
+    const err = new xrpl.RippledError('error message');
+    expect(checkRippledErrorResponse(err)).toBeUndefined();
+  });
+
+  it('ignores Error', () => {
+    expect(checkRippledErrorResponse(new Error('other'))).toBeUndefined();
+  });
+
+  it('ignores Error with data', () => {
+    const error = new Error('other');
+    (error as any).data = exampleErrorResponse;
+    expect(checkRippledErrorResponse(error)).toBeUndefined();
   });
 });

--- a/web-client/src/app/services/xrpl.utils.ts
+++ b/web-client/src/app/services/xrpl.utils.ts
@@ -119,3 +119,23 @@ export const getTxResponseMetadata = (
     return meta;
   }
 };
+
+/**
+ * Check for `RippledError`, and extract its error response.
+ *
+ * This verifies that {@link xrpl.ErrorResponse.status} is `"error"`, at least.
+ */
+export const checkRippledErrorResponse = (
+  err: xrpl.RippledError | unknown
+): xrpl.ErrorResponse | undefined => {
+  if (err instanceof xrpl.RippledError) {
+    const maybeResponse = err.data as xrpl.ErrorResponse | any;
+    if (
+      typeof maybeResponse === 'object' &&
+      'status' in maybeResponse &&
+      maybeResponse.status === 'error'
+    ) {
+      return maybeResponse as xrpl.ErrorResponse;
+    }
+  }
+};

--- a/web-client/src/app/state/session-xrpl.service.ts
+++ b/web-client/src/app/state/session-xrpl.service.ts
@@ -48,9 +48,16 @@ export class SessionXrplService {
     // TODO: Fetch the following in parallel, sharing a connection context.
 
     // Get AccountRoot entry:
-    const accountInfo = await this.xrplService.getAccountInfo({
+    const accountInfo = await this.xrplService.getAccountInfoIfExists({
       account: xrplAddress,
     });
+    if (accountInfo === undefined) {
+      console.log(
+        'SessionXrplService.loadAccountData: account not found, bailing out',
+        { xrplAddress }
+      );
+      return;
+    }
     const xrplAccountRoot: xrpl.LedgerEntry.AccountRoot =
       accountInfo.result.account_data;
 

--- a/web-client/src/app/views/wallet/wallet.page.ts
+++ b/web-client/src/app/views/wallet/wallet.page.ts
@@ -7,6 +7,7 @@ import { SessionXrplService } from 'src/app/state/session-xrpl.service';
 import { SessionQuery } from 'src/app/state/session.query';
 import { SessionService } from 'src/app/state/session.service';
 import { AssetAmount } from 'src/app/utils/assets/assets.common';
+import { withConsoleGroup } from 'src/app/utils/console.helpers';
 import { defined } from 'src/app/utils/errors/panic';
 import { withLoadingOverlayOpts } from 'src/app/utils/loading.helpers';
 import { SwalHelper } from 'src/app/utils/notification/swal-helper';
@@ -72,16 +73,17 @@ export class WalletPage implements OnInit {
     await withLoadingOverlayOpts(
       this.loadingController,
       { message: 'Refreshing…' },
-      async () => {
-        await Promise.all([
-          (async () => {
-            await this.sessionAlgorandService.loadAccountData();
-            await this.sessionAlgorandService.loadAssetParams();
-          })(),
-          this.sessionXrplService.loadAccountData(),
-          this.sessionService.loadOnfidoCheck(),
-        ]);
-      }
+      async () =>
+        await withConsoleGroup('WalletPage.onRefresh:', async () => {
+          await Promise.all([
+            (async () => {
+              await this.sessionAlgorandService.loadAccountData();
+              await this.sessionAlgorandService.loadAssetParams();
+            })(),
+            this.sessionXrplService.loadAccountData(),
+            this.sessionService.loadOnfidoCheck(),
+          ]);
+        })
     );
   }
 


### PR DESCRIPTION
This handles the initial empty XRPL account state gracefully, rather than crashing.