### PR TITLE
feat(web-client): add SMS messaging

### DIFF
--- a/web-client/src/app/services/messaging.service.spec.ts
+++ b/web-client/src/app/services/messaging.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed } from '@angular/core/testing';
+import { MessagingService } from './messaging.service';
+
+describe('MessagingService', () => {
+  let service: MessagingService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(MessagingService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/web-client/src/app/services/messaging.service.spec.ts
+++ b/web-client/src/app/services/messaging.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { MessagingService } from './messaging.service';
 
@@ -5,7 +6,9 @@ describe('MessagingService', () => {
   let service: MessagingService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(MessagingService);
   });
 

--- a/web-client/src/app/services/messaging.service.ts
+++ b/web-client/src/app/services/messaging.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class MessagingService {
+  constructor() {}
+}

--- a/web-client/src/app/services/messaging.service.ts
+++ b/web-client/src/app/services/messaging.service.ts
@@ -1,8 +1,31 @@
 import { Injectable } from '@angular/core';
+import { NautilusAssetServicesService } from 'src/app/services/nautilus-asset-services.service';
 
 @Injectable({
   providedIn: 'root',
 })
 export class MessagingService {
-  constructor() {}
+  constructor(private nautilusAssetServices: NautilusAssetServicesService) {}
+
+  async sendMessage(message: SendMessage): Promise<Message> {
+    return await this.nautilusAssetServices.post<SendMessage, Message>(
+      'messages/create',
+      message
+    );
+  }
 }
+
+type SendMessage = {
+  to_phone_number: string;
+  body: string;
+};
+
+/**
+ * @see https://www.twilio.com/docs/sms/api/message-resource#message-properties
+ */
+export type Message = {
+  account_sid?: string;
+  sid?: string;
+
+  // TODO: Remaining fields, if needed.
+};

--- a/web-client/src/app/services/nautilus-asset-services.service.spec.ts
+++ b/web-client/src/app/services/nautilus-asset-services.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { NautilusAssetServicesService } from './nautilus-asset-services.service';
 
@@ -5,7 +6,9 @@ describe('NautilusAssetServicesService', () => {
   let service: NautilusAssetServicesService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(NautilusAssetServicesService);
   });
 

--- a/web-client/src/app/services/nautilus-asset-services.service.spec.ts
+++ b/web-client/src/app/services/nautilus-asset-services.service.spec.ts
@@ -1,0 +1,15 @@
+import { TestBed } from '@angular/core/testing';
+import { NautilusAssetServicesService } from './nautilus-asset-services.service';
+
+describe('NautilusAssetServicesService', () => {
+  let service: NautilusAssetServicesService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NautilusAssetServicesService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/web-client/src/app/services/nautilus-asset-services.service.ts
+++ b/web-client/src/app/services/nautilus-asset-services.service.ts
@@ -1,8 +1,24 @@
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
+import { environment } from 'src/environments/environment';
 
 @Injectable({
   providedIn: 'root',
 })
 export class NautilusAssetServicesService {
-  constructor() {}
+  constructor(private http: HttpClient) {}
+
+  async post<Request = object, Response = object>(
+    path: string,
+    body: Request
+  ): Promise<Response> {
+    const url = this.getAssetServicesUrl(path);
+    const response = await firstValueFrom(this.http.post(url, body));
+    return response as Response; // XXX: Unchecked cast
+  }
+
+  protected getAssetServicesUrl(path: string): string {
+    return new URL(path, environment.nautilusAssetServices).toString();
+  }
 }

--- a/web-client/src/app/services/nautilus-asset-services.service.ts
+++ b/web-client/src/app/services/nautilus-asset-services.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class NautilusAssetServicesService {
+  constructor() {}
+}

--- a/web-client/src/app/services/onfido.service.ts
+++ b/web-client/src/app/services/onfido.service.ts
@@ -1,19 +1,19 @@
-import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { panic } from 'src/app/utils/errors/panic';
-import { environment } from 'src/environments/environment';
+import { NautilusAssetServicesService } from './nautilus-asset-services.service';
 
 @Injectable({ providedIn: 'root' })
 export class OnfidoService {
-  constructor(private http: HttpClient) {}
+  constructor(private nautilusAssetServices: NautilusAssetServicesService) {}
 
   async start(
     first_name: string,
     last_name: string
   ): Promise<OnfidoKycStarted> {
-    const url = this.getAssetServicesUrl('kyc/start');
-    const body: StartKyc = { first_name, last_name };
-    const response = await this.http.post(url, body).toPromise();
+    const response = await this.nautilusAssetServices.post<StartKyc>(
+      'kyc/start',
+      { first_name, last_name }
+    );
     return checkedOnfidoKycStarted(response);
   }
 
@@ -21,21 +21,20 @@ export class OnfidoService {
     applicant_id: string,
     report_names: Array<string>
   ): Promise<Check> {
-    const url = this.getAssetServicesUrl('kyc/checks/create');
-    const body: CreateCheck = { applicant_id, report_names };
-    const response = await this.http.post(url, body).toPromise();
-    return response as Check; // XXX: Unchecked cast
+    return await this.nautilusAssetServices.post<CreateCheck, Check>(
+      'kyc/checks/create',
+      {
+        applicant_id,
+        report_names,
+      }
+    );
   }
 
   async retrieveCheck(check_id: string): Promise<Check> {
-    const url = this.getAssetServicesUrl('kyc/checks/retrieve');
-    const body: RetrieveCheck = { check_id };
-    const response = await this.http.post(url, body).toPromise();
-    return response as Check; // XXX: Unchecked cast
-  }
-
-  protected getAssetServicesUrl(path: string): string {
-    return new URL(path, environment.nautilusAssetServices).toString();
+    return await this.nautilusAssetServices.post<RetrieveCheck, Check>(
+      'kyc/checks/retrieve',
+      { check_id }
+    );
   }
 }
 

--- a/web-client/src/app/views/register/register.page.ts
+++ b/web-client/src/app/views/register/register.page.ts
@@ -22,6 +22,8 @@ export class RegisterPage implements OnInit {
     rightAlign: false,
     placeholder: '',
   });
+  // TODO(Pi): We should replace this with something that handles international numbers (probably libphonenumber-based?)
+  //           (See also: E-164 hack in SessionService.)
   phoneInputMask = createMask({
     mask: '(999) 999-99-99',
     autoUnmask: true,


### PR DESCRIPTION
Summary:

- Factor out `NautilusAssetServicesService`
- Add `MessagingService`
- Send SMS after `SessionService.saveOnfidoCheck`

### Related

- Uses functionality from https://github.com/ntls-io/nautilus-wallet/pull/201 
- Follows https://github.com/ntls-io/nautilus-wallet/pull/202