### PR TITLE
chore(web-client): Enable a message to let user know there are no assets #217

### DIFF
--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.html
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.html
@@ -4,23 +4,23 @@
   </ion-card-header>
 
   <ion-card-content>
-    <ion-list lines="none">
-      <ion-grid>
-        <ng-container *ngFor="let balance of balances">
-          <ion-row class="ion-align-items-center">
-            <ion-col size="7" class="ion-text-end">
-              <ion-text color="white" class="text-2xl font-audiowide">
-                {{ balance | assetAmount }}
-              </ion-text>
-            </ion-col>
-            <ion-col size="5" class="ion-text-start">
-              <ion-text color="secondary" class="font-bold">
-                {{ balance | assetSymbol }}
-              </ion-text>
-            </ion-col>
-          </ion-row>
-        </ng-container>
-      </ion-grid>
-    </ion-list>
+    <ion-grid *ngIf="false; else empty">
+      <ion-row class="ion-align-items-center" *ngFor="let balance of balances">
+        <ion-col size="7" class="ion-text-end">
+          <ion-text color="white" class="text-2xl font-audiowide">
+            {{ balance | assetAmount }}
+          </ion-text>
+        </ion-col>
+        <ion-col size="5" class="ion-text-start">
+          <ion-text color="secondary" class="font-bold">
+            {{ balance | assetSymbol }}
+          </ion-text>
+        </ion-col>
+      </ion-row>
+    </ion-grid>
+
+    <ng-template #empty>
+      <p>There are currently no assets in your wallet.</p>
+    </ng-template>
   </ion-card-content>
 </ion-card>

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.html
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.html
@@ -4,7 +4,7 @@
   </ion-card-header>
 
   <ion-card-content>
-    <ion-grid *ngIf="false; else empty">
+    <ion-grid *ngIf="noBalance; else empty">
       <ion-row class="ion-align-items-center" *ngFor="let balance of balances">
         <ion-col size="7" class="ion-text-end">
           <ion-text color="white" class="text-2xl font-audiowide">

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.html
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.html
@@ -4,7 +4,7 @@
   </ion-card-header>
 
   <ion-card-content>
-    <ion-grid *ngIf="noBalance; else empty">
+    <ion-grid *ngIf="balances?.length; else empty">
       <ion-row class="ion-align-items-center" *ngFor="let balance of balances">
         <ion-col size="7" class="ion-text-end">
           <ion-text color="white" class="text-2xl font-audiowide">

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.ts
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.ts
@@ -8,7 +8,6 @@ import { AssetAmount } from 'src/app/utils/assets/assets.common';
 })
 export class BalanceSummaryCardComponent implements OnInit {
   @Input() balances?: AssetAmount[] | null;
-  noBalance = false;
 
   constructor() {}
 

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.ts
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.ts
@@ -8,6 +8,7 @@ import { AssetAmount } from 'src/app/utils/assets/assets.common';
 })
 export class BalanceSummaryCardComponent implements OnInit {
   @Input() balances?: AssetAmount[] | null;
+  noBalance = false;
 
   constructor() {}
 


### PR DESCRIPTION
A message that indicates that there are no assets when opening wallet for the first time.

Related to:
[217](https://github.com/ntls-io/nautilus-wallet/issues/217)