### PR TITLE
chore(web-client): Error color contrast is hard to read

### DIFF
--- a/web-client/src/theme/variables.scss
+++ b/web-client/src/theme/variables.scss
@@ -71,7 +71,7 @@
   --ion-color-warning-tint: #ffdd63;
 
   // Ui Kit: Danger - Red Salsa
-  --ion-color-danger: #ff2d42;
+  --ion-color-danger: #ff6578;
   --ion-color-danger-rgb: 255, 45, 66;
   --ion-color-danger-contrast: #ffffff;
   --ion-color-danger-contrast-rgb: 255, 255, 255;


### PR DESCRIPTION
The current shade of red on blue is hard to read, especially for colour
blindness. The error color has been changed to comply with AA version of
WCAG.
![option_1](https://user-images.githubusercontent.com/68713894/169985732-6edcfdc1-ba84-4550-99ea-eb4ef4b76a0f.png)
