### PR TITLE
fix(web-client): set trustline limit to 0 if limit_peer is 0

### DIFF
--- a/web-client/src/app/views/delete-user/delete-user.page.html
+++ b/web-client/src/app/views/delete-user/delete-user.page.html
@@ -14,10 +14,6 @@
     You will need to enter a wallet address to send your remaining XRP balance
     to.
   </p>
-  <p style="font-size: 80%">
-    For other account balances, please make sure you transfer remaining balances
-    through the <strong>Send Money tab</strong>.
-  </p>
 </div>
 
 <ion-grid fixed>


### PR DESCRIPTION
Magically fixes the delete feature ;) 

https://app.clickup.com/t/2b0107c

### Current Flow
1. Nautilus Issuer (FOO) creates Trustline with Wallet A with limit 1000
2. Wallet A matches Trustline `limit_peer` to 1000 so that it can receive FOO - https://github.com/ntls-io/nautilus-wallet/blob/dc4e1ac4f801ac196f8269d33bf25c4efae15706/web-client/src/app/state/session-xrpl.service.ts#L287

Now if we want to delete Wallet A account, we need to remove Trustline
3. Nautilus Issuer (FOO) defaults Trustline with Wallet A with limit 0

But now Wallet A still has it's limit at 1000

This PR will provide step 4:
4. Wallet A matches Trustline `limit_peer` to 0 so that trustline can be defaulted (severed).
5. Voila, you can delete Wallet A!!!!