### PR TITLE
feat(web-client): modify XRP trustline user flow

### DIFF
--- a/web-client/src/app/services/xrpl.service.ts
+++ b/web-client/src/app/services/xrpl.service.ts
@@ -150,7 +150,7 @@ export class XrplService {
   async createUnsignedTrustSetTx(
     fromAddress: string,
     limitAmount: IssuedCurrencyAmount,
-    flags?: number | xrpl.TrustSetFlagsInterface,
+    flags?: number | xrpl.TrustSetFlagsInterface
   ): Promise<xrpl.TrustSet> {
     const unpreparedTx: xrpl.TrustSet = {
       Account: fromAddress,

--- a/web-client/src/app/services/xrpl.service.ts
+++ b/web-client/src/app/services/xrpl.service.ts
@@ -149,13 +149,18 @@ export class XrplService {
 
   async createUnsignedTrustSetTx(
     fromAddress: string,
-    limitAmount: IssuedCurrencyAmount
+    limitAmount: IssuedCurrencyAmount,
+    flags?: number | xrpl.TrustSetFlagsInterface,
   ): Promise<xrpl.TrustSet> {
     const unpreparedTx: xrpl.TrustSet = {
       Account: fromAddress,
       TransactionType: 'TrustSet',
       LimitAmount: limitAmount,
     };
+    if (typeof flags !== 'undefined') {
+      unpreparedTx.Flags = flags;
+    }
+
     return await this.withConnection(
       async (client) => await client.autofill(unpreparedTx)
     );

--- a/web-client/src/app/state/session-xrpl.service.ts
+++ b/web-client/src/app/state/session-xrpl.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
-import { EnclaveService } from '../services/enclave';
 import { XrplService } from 'src/app/services/xrpl.service';
 import {
   checkTxResponseSucceeded,
@@ -18,6 +17,7 @@ import { TransactionSigned, TransactionToSign } from 'src/schema/actions';
 import * as xrpl from 'xrpl';
 import { IssuedCurrencyAmount } from 'xrpl/dist/npm/models/common';
 import { Trustline } from 'xrpl/dist/npm/models/methods/accountLines';
+import { EnclaveService } from '../services/enclave';
 import { ConnectorQuery } from './connector';
 import { SessionQuery } from './session.query';
 import { SessionStore, XrplBalance } from './session.store';
@@ -207,7 +207,7 @@ export class SessionXrplService {
    */
   async sendTrustSetTx(
     limitAmount: IssuedCurrencyAmount,
-    flags?: number | xrpl.TrustSetFlagsInterface,
+    flags?: number | xrpl.TrustSetFlagsInterface
   ): Promise<xrpl.TxResponse> {
     const { wallet } = this.sessionQuery.assumeActiveSession();
 

--- a/web-client/src/app/state/session-xrpl.service.ts
+++ b/web-client/src/app/state/session-xrpl.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
-import { EnclaveService } from 'src/app/services/enclave/index';
+import { EnclaveService } from '../services/enclave';
 import { XrplService } from 'src/app/services/xrpl.service';
 import {
   checkTxResponseSucceeded,
@@ -16,7 +16,7 @@ import { parseNumber } from 'src/app/utils/validators';
 import { ifDefined } from 'src/helpers/helpers';
 import { TransactionSigned, TransactionToSign } from 'src/schema/actions';
 import * as xrpl from 'xrpl';
-import { IssuedCurrencyAmount } from 'xrpl/dist/npm/models/common/index';
+import { IssuedCurrencyAmount } from 'xrpl/dist/npm/models/common';
 import { Trustline } from 'xrpl/dist/npm/models/methods/accountLines';
 import { ConnectorQuery } from './connector';
 import { SessionQuery } from './session.query';
@@ -206,7 +206,8 @@ export class SessionXrplService {
    * @see XrplService.createUnsignedTrustSetTx
    */
   async sendTrustSetTx(
-    limitAmount: IssuedCurrencyAmount
+    limitAmount: IssuedCurrencyAmount,
+    flags?: number | xrpl.TrustSetFlagsInterface,
   ): Promise<xrpl.TxResponse> {
     const { wallet } = this.sessionQuery.assumeActiveSession();
 
@@ -215,7 +216,8 @@ export class SessionXrplService {
       async () =>
         await this.xrplService.createUnsignedTrustSetTx(
           wallet.xrpl_account.address_base58,
-          limitAmount
+          limitAmount,
+          flags
         ),
       { from: wallet.xrpl_account.address_base58, limitAmount }
     );

--- a/web-client/src/app/state/session-xrpl.service.ts
+++ b/web-client/src/app/state/session-xrpl.service.ts
@@ -320,6 +320,43 @@ export class SessionXrplService {
     }
   }
 
+  /**
+   * Helper: Create a trust line between active session's wallet and targeted account.
+   *
+   * This creates and sends a `TrustSet` transaction.
+   *
+   * @return the `TrustSet` response, or undefined
+   */
+  async createTrustline(
+    currency: string,
+    issuer: string,
+    value: string,
+    rippling: boolean
+  ): Promise<xrpl.TxResponse | undefined> {
+    const limitAmount = {
+      currency,
+      issuer,
+      value,
+    };
+
+    if (rippling) {
+      const enableRippling: xrpl.TrustSetFlagsInterface = {
+        tfClearNoRipple: true,
+      };
+      return await withLoggedExchange(
+        'SessionXrplService.createTrustline: sending TrustSet',
+        async () => await this.sendTrustSetTx(limitAmount, enableRippling),
+        limitAmount
+      );
+    }
+
+    return await withLoggedExchange(
+      'SessionXrplService.createTrustline: sending TrustSet',
+      async () => await this.sendTrustSetTx(limitAmount),
+      limitAmount
+    );
+  }
+
   protected async prepareUnsignedTransaction(
     receiverId: string,
     amount: xrpl.Payment['Amount']

--- a/web-client/src/app/state/session-xrpl.service.ts
+++ b/web-client/src/app/state/session-xrpl.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
 import { firstValueFrom } from 'rxjs';
+import { EnclaveService } from 'src/app/services/enclave';
 import { XrplService } from 'src/app/services/xrpl.service';
 import {
   checkTxResponseSucceeded,
@@ -17,7 +18,6 @@ import { TransactionSigned, TransactionToSign } from 'src/schema/actions';
 import * as xrpl from 'xrpl';
 import { IssuedCurrencyAmount } from 'xrpl/dist/npm/models/common';
 import { Trustline } from 'xrpl/dist/npm/models/methods/accountLines';
-import { EnclaveService } from '../services/enclave';
 import { ConnectorQuery } from './connector';
 import { SessionQuery } from './session.query';
 import { SessionStore, XrplBalance } from './session.store';

--- a/web-client/src/app/state/session-xrpl.service.ts
+++ b/web-client/src/app/state/session-xrpl.service.ts
@@ -255,11 +255,11 @@ export class SessionXrplService {
       (await firstValueFrom(this.sessionQuery.xrplTrustlines)) ?? [];
 
     const txResponses: xrpl.TxResponse[] = [];
-    for (const trustLine of trustLines) {
-      ifDefined(await this.checkTrustlineOptIn(trustLine), (txResponse) =>
-        txResponses.push(txResponse)
-      );
-    }
+    // for (const trustLine of trustLines) {
+    //   ifDefined(await this.checkTrustlineOptIn(trustLine), (txResponse) =>
+    //     txResponses.push(txResponse)
+    //   );
+    // }
     return txResponses;
   }
 

--- a/web-client/src/app/views/delete-user/delete-user.page.ts
+++ b/web-client/src/app/views/delete-user/delete-user.page.ts
@@ -138,7 +138,7 @@ export class DeleteUserPage implements OnInit {
   async refreshWalletData(): Promise<void> {
     this.balancesIsLoading = true;
     try {
-      await withConsoleGroup('WalletPage.refreshWalletData:', async () => {
+      await withConsoleGroup('DeleteUserPage.refreshWalletData:', async () => {
         await withConsoleGroupCollapsed('Loading wallet data', async () => {
           await Promise.all([
             (async () => {
@@ -207,7 +207,7 @@ export class DeleteUserPage implements OnInit {
       });
       if (0 < unsuccessfulResponses.length) {
         console.log(
-          'DekewteUserPage.checkXrplTokenOptIns: unsuccessful responses:',
+          'DeleteUserPage.checkXrplTokenOptIns: unsuccessful responses:',
           { unsuccessfulResponses }
         );
         const errorMessage: string = unsuccessfulResponses


### PR DESCRIPTION
This PR modifies the current XRP trustline user flow:
* Pause opportunistic XRPL token opt-in
* Add createTrustline method (Need to call this from frontend to createTrustline)
* Automatically default all XRPL Trustline opt-ins when deleting wallet

Current flow is documented in https://github.com/ntls-io/nautilus-wallet/pull/292 and https://app.clickup.com/t/2m9gnkw.
![image](https://user-images.githubusercontent.com/31125065/181023323-cb0e9bbc-0028-429d-9109-05467449757a.png)

