### PR TITLE
fix(web-client): hide verify menu if already done

### DIFF
--- a/web-client/src/app/views/wallet/wallet.page.html
+++ b/web-client/src/app/views/wallet/wallet.page.html
@@ -21,19 +21,35 @@
 
   <ion-list lines="none">
     <ion-item
-      *ngFor="let item of actionItems"
+      *ngIf="(sessionQuery.onfidoCheckIsClear | async) !== true"
       class="app-item"
       button
       detail
       detailIcon="chevron-forward-circle"
       class="app-item"
-      [routerLink]="item.path"
-      [disabled]="item.disabled"
+      routerLink="/kyc"
     >
-      <ion-icon slot="start" [name]="item.icon"></ion-icon>
+      <ion-icon slot="start" name="finger-print"></ion-icon>
       <ion-label>
-        <ion-text class="block font-bold"> {{item.title}} </ion-text>
+        <ion-text class="block font-bold"> Verify Profile </ion-text>
       </ion-label>
     </ion-item>
+
+    <ng-container *ngFor="let item of actionItems">
+      <ion-item
+        class="app-item"
+        button
+        detail
+        detailIcon="chevron-forward-circle"
+        class="app-item"
+        [routerLink]="item.path"
+        [disabled]="item.disabled"
+      >
+        <ion-icon slot="start" [name]="item.icon"></ion-icon>
+        <ion-label>
+          <ion-text class="block font-bold"> {{item.title}} </ion-text>
+        </ion-label>
+      </ion-item>
+    </ng-container>
   </ion-list>
 </ion-content>

--- a/web-client/src/app/views/wallet/wallet.page.ts
+++ b/web-client/src/app/views/wallet/wallet.page.ts
@@ -39,12 +39,6 @@ export class WalletPage implements OnInit {
 
   actionItems = [
     {
-      title: 'Verify Profile',
-      icon: 'finger-print',
-      path: '/kyc',
-      disabled: false,
-    },
-    {
       title: 'Send Money',
       icon: 'card',
       path: '/wallet/send-funds',
@@ -58,16 +52,7 @@ export class WalletPage implements OnInit {
     },
   ];
 
-  constructor(public sessionQuery: SessionQuery) {
-    this.sessionQuery.onfidoCheckIsClear.subscribe((onfidoCheckIsClear) => {
-      console.log(onfidoCheckIsClear);
-      this.actionItems.find((item) => {
-        if (item.title === 'Verify Profile') {
-          item.disabled = !onfidoCheckIsClear;
-        }
-      });
-    });
-  }
+  constructor(public sessionQuery: SessionQuery) {}
 
   ngOnInit() {}
 }


### PR DESCRIPTION
This fix hide the "Verify Profile" menu item if the wallet was already verified