### PR TITLE
fix(web-client): optin only if wallet has xrp

### DIFF
--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.html
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.html
@@ -41,7 +41,7 @@
     </ion-list>
 
     <app-asset-accordion
-      *ngIf="!isLoading && !showAsset"
+      *ngIf="!isLoading && showAsset"
       (refreshBalances)="refreshWalletData()"
     ></app-asset-accordion>
   </ng-container>

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.ts
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.ts
@@ -33,9 +33,16 @@ export class BalanceSummaryCardComponent implements OnInit {
     private notification: SwalHelper
   ) {
     this.sessionQuery.allBalances.subscribe((balances) => {
-      this.showAsset = balances?.some(
-        (e: AssetAmount) => e?.assetDisplay.assetSymbol === 'FOO'
+      const hasXRP = balances.some(
+        ({ assetDisplay, amount }) =>
+          assetDisplay?.assetSymbol === 'XRP' && amount > 0.01
       );
+
+      if (hasXRP) {
+        this.showAsset = !balances?.some(
+          (e: AssetAmount) => e?.assetDisplay.assetSymbol === 'FOO'
+        );
+      }
     });
   }
 

--- a/web-client/src/app/components/balance-summary-card/balance-summary-card.component.ts
+++ b/web-client/src/app/components/balance-summary-card/balance-summary-card.component.ts
@@ -35,7 +35,7 @@ export class BalanceSummaryCardComponent implements OnInit {
     this.sessionQuery.allBalances.subscribe((balances) => {
       const hasXRP = balances.some(
         ({ assetDisplay, amount }) =>
-          assetDisplay?.assetSymbol === 'XRP' && amount > 0.01
+          assetDisplay?.assetSymbol === 'XRP' && amount > 0.0001
       );
 
       if (hasXRP) {


### PR DESCRIPTION
Check the wallet's initial balance (XRP) before showing the opt-in option.
The minimum is set to 0.01 which should be enough for the opt-in fee