### PR TITLE
[WIP] feat(web-server): initial wallet enclave sessions

### DIFF
--- a/web-server/sgx-wallet-impl/Cargo.lock
+++ b/web-server/sgx-wallet-impl/Cargo.lock
@@ -132,6 +132,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.4"
 source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
@@ -192,10 +201,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1079fb8528d9f9c888b1e8aa651e6e079ade467323d58f75faf1d30b1808f540"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array 0.14.4",
+ "typenum",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -203,7 +231,7 @@ version = "0.8.0"
 source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
 dependencies = [
  "generic-array 0.12.4",
- "subtle",
+ "subtle 2.2.2",
 ]
 
 [[package]]
@@ -241,6 +269,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+ "subtle 2.4.1",
 ]
 
 [[package]]
@@ -319,12 +358,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "hmac-drbg"
 version = "0.1.2"
 source = "git+https://github.com/mesalock-linux/hmac-drbg-rs-sgx#89d6b0113157599417af867a8d2b4afd5c6f1946"
 dependencies = [
  "generic-array 0.12.4",
- "hmac",
+ "hmac 0.7.1",
 ]
 
 [[package]]
@@ -398,7 +446,7 @@ dependencies = [
  "rand",
  "sgx_tstd",
  "sha2 0.8.0",
- "subtle",
+ "subtle 2.2.2",
  "typenum",
 ]
 
@@ -681,6 +729,7 @@ dependencies = [
  "algonaut",
  "base64",
  "hex",
+ "hmac 0.12.1",
  "rand",
  "ripple-address-codec",
  "ripple-keypairs",
@@ -694,6 +743,7 @@ dependencies = [
  "sgx_tse",
  "sgx_tstd",
  "sgx_types",
+ "sha2 0.10.2",
  "sodalite",
  "thiserror",
  "zeroize",
@@ -815,9 +865,20 @@ checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures 0.2.3",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -856,6 +917,12 @@ source = "git+https://github.com/mesalock-linux/subtle-sgx#8ee32fc0902a4594bd12e
 dependencies = [
  "sgx_tstd",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -901,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"

--- a/web-server/sgx-wallet-impl/Cargo.toml
+++ b/web-server/sgx-wallet-impl/Cargo.toml
@@ -14,7 +14,9 @@ test = false
 # no_std
 base64 = { version = "0.13.0", default-features = false, features = ["alloc"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
+hmac = { version = "0.12.1", default-features = false, features = ["reset"] }
 secrecy = "0.8.0"
+sha2 = { version = "0.10.2", default-features = false, features = [] }
 sodalite = { version = "0.4.0", default-features = false }
 zeroize = { version = "1.5.3", features = ["alloc", "zeroize_derive"] }
 

--- a/web-server/sgx-wallet-impl/src/schema/mod.rs
+++ b/web-server/sgx-wallet-impl/src/schema/mod.rs
@@ -25,4 +25,5 @@ pub mod entities;
 pub mod msgpack;
 pub mod sealing;
 pub(crate) mod serde_bytes_array;
+pub mod session;
 pub mod types;

--- a/web-server/sgx-wallet-impl/src/schema/session.rs
+++ b/web-server/sgx-wallet-impl/src/schema/session.rs
@@ -1,0 +1,85 @@
+use std::vec::Vec;
+
+use hmac::{Hmac, Mac};
+use rand::RngCore;
+use secrecy::Zeroize;
+use sgx_trts::memeq::ConsttimeMemEq;
+use sha2::Sha512_256;
+use zeroize::ZeroizeOnDrop;
+
+use crate::schema::entities::SessionStorable;
+
+type HmacSha512_256 = Hmac<Sha512_256>;
+
+const SESSION_KEY_LENGTH: usize = 32;
+
+/// Validate a new message that pertains to a previously sent one, using
+/// cryptographically established sessions with the enclave.
+///
+/// Session state is generated using a keyed hash of the initial message, using
+/// a randomly generated key. An internal session id, i.e. the aforementioned
+/// hash, is checked *before* the message is validated.
+#[derive(Clone, Eq, PartialEq, Debug)] //core
+#[derive(Zeroize, ZeroizeOnDrop)] // zeroize
+pub struct Session {
+    pub id: Vec<u8>,
+    pub key: Vec<u8>,
+}
+
+impl TryFrom<SessionStorable> for Session {
+    type Error = base64::DecodeError;
+    fn try_from(stored: SessionStorable) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: base64::decode(&stored.session_id)?,
+            key: base64::decode(&stored.session_key)?,
+        })
+    }
+}
+
+fn create_mac_context(key: &[u8], msg: &[u8]) -> HmacSha512_256 {
+    // XXX(PANIC): the following panics the thread if the supplied key's length is invalid
+    let mut mac = HmacSha512_256::new_from_slice(&key).unwrap();
+    mac.update(msg);
+    mac
+}
+
+impl Session {
+    /// Generate a new wallet enclave session.
+    pub fn new(msg: &[u8]) -> Self {
+        let mut key = Vec::with_capacity(SESSION_KEY_LENGTH);
+        rand::thread_rng().fill_bytes(&mut key);
+
+        let mut mac = create_mac_context(&key, msg);
+        let id = mac.finalize_reset().into_bytes().to_vec();
+
+        Self { id, key }
+    }
+    /// Validate and authenticate a new message based on state generated in connection with a prior message.
+    pub fn validate_new_msg(
+        &self,
+        session_id: &[u8],
+        new_msg: &[u8],
+        tag: &[u8],
+    ) -> ValidateMsgResult {
+        match ConsttimeMemEq::consttime_memeq(self.id.as_slice(), session_id) {
+            false => ValidateMsgResult::InvalidSessionId,
+            true => {
+                let mac = create_mac_context(&self.key, new_msg);
+                match mac.verify_slice(tag) {
+                    Ok(()) => ValidateMsgResult::Valid,
+                    _ => ValidateMsgResult::InvalidMsg,
+                }
+            }
+        }
+    }
+}
+
+/// Validation result.
+///
+/// Note that the internal session id check happens *before* validation of the
+/// new message.
+pub enum ValidateMsgResult {
+    Valid,
+    InvalidSessionId,
+    InvalidMsg,
+}

--- a/web-server/sgx-wallet-impl/src/schema/types.rs
+++ b/web-server/sgx-wallet-impl/src/schema/types.rs
@@ -6,6 +6,9 @@ use std::prelude::v1::String;
 use ripple_keypairs::{Algorithm, EntropyArray};
 use serde::{Deserialize, Serialize};
 
+/// A base64-encoded string.
+pub type Base64String = String;
+
 pub type Bytes = Box<[u8]>;
 
 /// Nautilus Wallet ID.

--- a/web-server/sgx-wallet-impl/src/wallet_operations/create_wallet.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/create_wallet.rs
@@ -16,6 +16,9 @@ pub fn create_wallet(request: &CreateWallet) -> Result {
         wallet_id: new_xrpl_account.to_address_base58(),
         owner_name: request.owner_name.clone(),
         auth_pin: request.auth_pin.clone(),
+
+        session: None,
+
         phone_number: request.phone_number.clone(),
 
         algorand_account: new_algorand_account,


### PR DESCRIPTION
### Overview

Certain multi-step wallet operations require that two or more messages related messages be sent for processing by the enclave.   Since the enclave has no built-in means of verifying that such messages are indeed from the same source, a cryptographic mechanism is necessary to essentially establish "sessions" across such messages.

### Aim
 
Provide a simple, albeit rudimentary, solution to the aforementioned problem through the use of randomly generated session keys and using keyed hashes of prior messages as a session identifier.

### Context

The need for this functionality arose in the context of PR #324, where authentication details need to be verified prior to a follow-up message that contains the new to-be PIN for the user wallet.  The enclave needs some mechanism by which it can verify that the latter message originates from the same source as the former containing the user responses to pre-defined security questions.