### PR TITLE
feat: initial wallet enclave sessions

### DIFF
--- a/web-client/src/schema/crypto.ts
+++ b/web-client/src/schema/crypto.ts
@@ -19,7 +19,7 @@ type EncryptedMessage = {
 };
 
 export class TweetNaClCrypto {
-  constructor(public keyPair: BoxKeyPair) { }
+  constructor(public keyPair: BoxKeyPair) {}
 
   get public_key(): PublicKey {
     return this.keyPair.publicKey;

--- a/web-client/src/schema/crypto.ts
+++ b/web-client/src/schema/crypto.ts
@@ -19,7 +19,7 @@ type EncryptedMessage = {
 };
 
 export class TweetNaClCrypto {
-  constructor(public keyPair: BoxKeyPair) {}
+  constructor(public keyPair: BoxKeyPair) { }
 
   get public_key(): PublicKey {
     return this.keyPair.publicKey;

--- a/web-client/src/schema/session.ts
+++ b/web-client/src/schema/session.ts
@@ -1,0 +1,57 @@
+/**
+ * Simple session support for the wallet enclave.
+ *
+ * For functionality that requires multiple exchanges between the client and
+ * enclave, it is necessary to establish a session cryptographically linking
+ * these exchanges together.
+ */
+
+import { HMAC } from '@stablelib/hmac/lib/hmac';
+import { SHA256 } from '@stablelib/sha256/lib/sha256';
+import { DiffieHellman, PublicKey, SharedSecret } from './crypto';
+import { Bytes, Bytes32, WalletId } from './types';
+
+export class StartSgxSession {
+  protected context: Bytes;
+
+  protected constructor(wallet_id: WalletId, ctx: Bytes = new Uint8Array(0)) {
+    /*
+     * Concatenate wallet id and supplied context into a combined context
+     */
+    const wallet_id_bytes = new TextEncoder().encode(wallet_id);
+    this.context = new Uint8Array(wallet_id_bytes.length + ctx.length);
+    this.context.set(wallet_id_bytes);
+    this.context.set(ctx, ctx.length);
+  }
+
+  static new = (wallet_id: WalletId, context?: Bytes): StartSgxSession =>
+    new StartSgxSession(wallet_id, context);
+
+  /**
+   * Configure the session with a public key received from the enclave. This
+   * method needs to be called before computing any MACs.
+   */
+  start_session = (their_pk: PublicKey): SgxSession => {
+    const dh = DiffieHellman.new(this.context);
+    return new SgxSession(dh, their_pk);
+  };
+}
+
+export class SgxSession {
+  readonly ourPk: PublicKey;
+  private readonly secret: SharedSecret;
+
+  constructor(protected dh: DiffieHellman, readonly theirPk: PublicKey) {
+    this.secret = dh.diffie_hellman(theirPk);
+    this.ourPk = dh.x25519_public_key();
+  }
+
+  /**
+   * Compute and return a message authentication code for an input message.
+   */
+  message_authentication_code = (msg: Bytes): Bytes32 => {
+    let hmac = new HMAC(SHA256, this.secret);
+    hmac.update(msg);
+    return hmac.digest();
+  };
+}

--- a/web-client/src/schema/session.ts
+++ b/web-client/src/schema/session.ts
@@ -50,7 +50,7 @@ export class SgxSession {
    * Compute and return a message authentication code for an input message.
    */
   message_authentication_code = (msg: Bytes): Bytes32 => {
-    let hmac = new HMAC(SHA256, this.secret);
+    const hmac = new HMAC(SHA256, this.secret);
     hmac.update(msg);
     return hmac.digest();
   };

--- a/web-server/sgx-wallet-impl/src/schema/mod.rs
+++ b/web-server/sgx-wallet-impl/src/schema/mod.rs
@@ -25,4 +25,5 @@ pub mod entities;
 pub mod msgpack;
 pub mod sealing;
 pub(crate) mod serde_bytes_array;
+pub mod session;
 pub mod types;

--- a/web-server/sgx-wallet-impl/src/schema/session.rs
+++ b/web-server/sgx-wallet-impl/src/schema/session.rs
@@ -1,0 +1,93 @@
+use std::io;
+use std::string::String;
+
+use hkdf::hmac::{Hmac, Mac};
+use sha2::Sha256;
+use thiserror::Error;
+
+use crate::crypto::common::*;
+use crate::crypto::key_agreement::DiffieHellman;
+use crate::crypto::sgx_get_key::SgxGetKey;
+use crate::schema::types::WalletId;
+use crate::wallet_operations::store::load_wallet;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Validate a new message that pertains to a previously sent one, using
+/// cryptographically established sessions with the enclave.
+#[derive(Debug)] //core
+pub struct Session {
+    id: WalletId,
+    keys: KeyPair,
+    shared_secret: Option<SharedSecret>,
+}
+
+#[derive(Debug, Error)]
+pub enum SessionError {
+    #[error("Wallet id {0:?} is invalid")]
+    InvalidWalletId(WalletId),
+    #[error("I/O error encountered while loading wallet")]
+    IoError(#[from] io::Error),
+}
+
+fn create_mac_context(key: PublicKey, info: &[u8]) -> HmacSha256 {
+    let mut mac = HmacSha256::new_from_slice(&key).unwrap();
+    mac.update(info);
+    mac
+}
+
+impl Session {
+    /// Generate a new wallet enclave session.
+    pub fn new(wallet_id: &str, context: &[u8]) -> Result<Self, SessionError> {
+        //TODO: error handling when serialization fails
+        let wallet_bytes = serde_json::to_vec(
+            &load_wallet(&wallet_id)?
+                .ok_or(SessionError::InvalidWalletId(String::from(wallet_id)))?,
+        )
+        .expect("Failed to serialize wallet storable");
+
+        let ctx = [wallet_bytes.as_slice(), context].concat();
+        let get_key = SgxGetKey::new(&ctx);
+
+        Ok(Self {
+            id: String::from(wallet_id),
+            keys: get_key.get_key(),
+            shared_secret: None,
+        })
+    }
+
+    /// Validate and authenticate a new message based on state generated in connection with a prior message.
+    pub fn validate_new_msg(
+        mut self,
+        their_pk: &PublicKey,
+        new_msg: &[u8],
+        tag: &[u8],
+    ) -> ValidateMsgResult {
+        match self.shared_secret {
+            None => {
+                /*
+                 * The DH context used here is simply the user's wallet id
+                 */
+                let key_agreement = DiffieHellman::new(self.keys, Some(self.id.as_bytes()));
+                self.shared_secret = Some(key_agreement.diffie_hellman(their_pk));
+            }
+            Some(_) => (),
+        }
+
+        let mac = create_mac_context(*self.shared_secret.expect("Should contain a value").expose_secret(), new_msg);
+        match mac.verify_slice(tag) {
+            Ok(()) => ValidateMsgResult::Valid,
+            _ => ValidateMsgResult::InvalidMsg,
+        }
+    }
+}
+
+/// Validation result.
+///
+/// Note that the internal session id check happens *before* validation of the
+/// new message.
+pub enum ValidateMsgResult {
+    Valid,
+    InvalidSessionId,
+    InvalidMsg,
+}

--- a/web-server/sgx-wallet-test/enclave/Cargo.lock
+++ b/web-server/sgx-wallet-test/enclave/Cargo.lock
@@ -144,6 +144,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "block-padding"
 version = "0.1.4"
 source = "git+https://github.com/mesalock-linux/rustcrypto-utils-sgx#07ebf780554e018037f750186d61ea9bdc031148"
@@ -210,10 +219,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array 0.14.4",
+ "typenum",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -221,7 +249,20 @@ version = "0.8.0"
 source = "git+https://github.com/mesalock-linux/rustcrypto-traits-sgx#7a5cb154f438c2401b3d8e37de96dd0acf8f493e"
 dependencies = [
  "generic-array 0.12.4",
- "subtle",
+ "subtle 2.2.2",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+dependencies = [
+ "byteorder 1.4.3",
+ "digest 0.9.0",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "subtle 2.4.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -259,6 +300,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.3",
+ "crypto-common",
+ "subtle 2.4.1",
 ]
 
 [[package]]
@@ -328,6 +380,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
+dependencies = [
+ "hmac 0.12.1",
+]
+
+[[package]]
 name = "hmac"
 version = "0.7.1"
 source = "git+https://github.com/mesalock-linux/rustcrypto-MACs-sgx#e8e1410b9c82d2e59da42fa8b0d8ed38e80a203c"
@@ -337,12 +398,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "hmac-drbg"
 version = "0.1.2"
 source = "git+https://github.com/mesalock-linux/hmac-drbg-rs-sgx#89d6b0113157599417af867a8d2b4afd5c6f1946"
 dependencies = [
  "generic-array 0.12.4",
- "hmac",
+ "hmac 0.7.1",
 ]
 
 [[package]]
@@ -416,7 +486,7 @@ dependencies = [
  "rand 0.7.3",
  "sgx_tstd",
  "sha2 0.8.0",
- "subtle",
+ "subtle 2.2.2",
  "typenum",
 ]
 
@@ -550,7 +620,7 @@ source = "git+https://github.com/mesalock-linux/rand-sgx#83583f073de3b4f75c3c3ef
 dependencies = [
  "getrandom 0.1.14",
  "rand_chacha 0.2.2",
- "rand_core 0.5.1",
+ "rand_core 0.5.1 (git+https://github.com/mesalock-linux/rand-sgx)",
  "sgx_tstd",
 ]
 
@@ -569,7 +639,7 @@ version = "0.2.2"
 source = "git+https://github.com/mesalock-linux/rand-sgx#83583f073de3b4f75c3c3ef5e174d484ed941f85"
 dependencies = [
  "ppv-lite86 0.2.6",
- "rand_core 0.5.1",
+ "rand_core 0.5.1 (git+https://github.com/mesalock-linux/rand-sgx)",
  "sgx_tstd",
 ]
 
@@ -582,6 +652,12 @@ dependencies = [
  "ppv-lite86 0.2.10",
  "rand_core 0.6.3",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 
 [[package]]
 name = "rand_core"
@@ -798,6 +874,7 @@ dependencies = [
  "algonaut",
  "base64",
  "hex",
+ "hkdf",
  "rand 0.7.3",
  "ripple-address-codec",
  "ripple-keypairs",
@@ -811,8 +888,10 @@ dependencies = [
  "sgx_tse",
  "sgx_tstd",
  "sgx_types",
+ "sha2 0.10.5",
  "sodalite",
  "thiserror",
+ "x25519-dalek",
  "zeroize",
 ]
 
@@ -969,9 +1048,20 @@ checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpufeatures",
+ "cpufeatures 0.1.5",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures 0.2.5",
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1010,6 +1100,12 @@ source = "git+https://github.com/mesalock-linux/subtle-sgx#8ee32fc0902a4594bd12e
 dependencies = [
  "sgx_tstd",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -1055,9 +1151,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
 name = "ucd-trie"
@@ -1170,6 +1266,17 @@ name = "wasm-bindgen-shared"
 version = "0.2.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e0c4a743a309662d45f4ede961d7afa4ba4131a59a639f29b0069c3798bbcc2"
+
+[[package]]
+name = "x25519-dalek"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a0c105152107e3b96f6a00a65e86ce82d9b125230e1c4302940eca58ff71f4f"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize",
+]
 
 [[package]]
 name = "x86"


### PR DESCRIPTION
### Overview

Certain multi-step wallet operations require that two or more messages related messages be sent for processing by the enclave.   Since the enclave has no built-in means of verifying that such messages are indeed from the same source, a cryptographic mechanism is necessary to essentially establish "sessions" across such messages.

### Aim
 
Provide a simple, albeit rudimentary, solution to the aforementioned problem through the use of a combination of a Diffie-Hellman key exchange and session keys deterministically generated by the enclave.

### Context

The need for this functionality arose in the context of PR #324, where authentication details need to be verified prior to a follow-up message that contains the new to-be PIN for the user wallet.  The enclave needs some mechanism by which it can verify that the latter message originates from the same source as the former containing the user responses to pre-defined security questions.