### PR TITLE
build(asset-services): update Rust edition to 2021

### DIFF
--- a/asset-services/Dockerfile
+++ b/asset-services/Dockerfile
@@ -4,7 +4,7 @@
 
 # Pre-stage build args:
 
-ARG RUST_TOOLCHAIN="1.55"
+ARG RUST_TOOLCHAIN="1.59"
 
 # For release builds, set both CARGO_BUILD_FLAGS="--release" and CARGO_OUTPUT_PROFILE="release"
 ARG CARGO_BUILD_FLAGS

--- a/asset-services/asset-services-api/Cargo.toml
+++ b/asset-services/asset-services-api/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Nautilus team"]
 license = "Apache-2.0"
 
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/asset-services/asset-services-celery/Cargo.toml
+++ b/asset-services/asset-services-celery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "asset-services-celery"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/asset-services/asset-services-worker/Cargo.toml
+++ b/asset-services/asset-services-worker/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "asset-services-worker"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/asset-services/onfido/Cargo.toml
+++ b/asset-services/onfido/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "onfido"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/asset-services/rust-toolchain.toml
+++ b/asset-services/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-channel = "1.56"
+channel = "1.59"

--- a/asset-services/rust-toolchain.toml
+++ b/asset-services/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-channel = "1.55"
+channel = "1.56"

--- a/asset-services/twilio-api/Cargo.toml
+++ b/asset-services/twilio-api/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Nautilus team"]
 license = "Apache-2.0"
 
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/asset-services/twilio-verify/Cargo.toml
+++ b/asset-services/twilio-verify/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Nautilus team"]
 license = "Apache-2.0"
 
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Bumping rust edition to 2021.
```
If you are trying to migrate from the previous edition (2018), the
process requires following these steps:

1. Start with `edition = "2018"` in `Cargo.toml`
2. Run `cargo fix --edition`
3. Modify `Cargo.toml` to set `edition = "2021"`
4. Run `cargo build` or `cargo test` to verify the fixes worked

More details may be found at
https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html
```

Was trying to use https://crates.io/crates/azure_data_cosmos crate but it was failing to build due to:
```
error: failed to download `time v0.3.14`

Caused by:
  unable to get packages from source

Caused by:
  failed to parse manifest at `/home/bill/.cargo/registry/src/github.com-1ecc6299db9ec823/time-0.3.14/Cargo.toml`

Caused by:
  feature `edition2021` is required

  The package requires the Cargo feature called `edition2021`, but that feature is not stabilized in this version of Cargo (1.55.0 (32da73ab1 2021-08-23)).
  Consider trying a newer version of Cargo (this may require the nightly release).
  See https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2021 for more information about the status of this feature.
```
https://github.com/time-rs/time - minimum rustc 1.59