### PR TITLE
build(asset-services): update Rust edition to 2021

### DIFF
--- a/asset-services/Dockerfile
+++ b/asset-services/Dockerfile
@@ -4,7 +4,7 @@
 
 # Pre-stage build args:
 
-ARG RUST_TOOLCHAIN="1.55"
+ARG RUST_TOOLCHAIN="1.59"
 
 # For release builds, set both CARGO_BUILD_FLAGS="--release" and CARGO_OUTPUT_PROFILE="release"
 ARG CARGO_BUILD_FLAGS

--- a/asset-services/asset-services-api/Cargo.toml
+++ b/asset-services/asset-services-api/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Nautilus team"]
 license = "Apache-2.0"
 
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/asset-services/asset-services-celery/Cargo.toml
+++ b/asset-services/asset-services-celery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "asset-services-celery"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/asset-services/asset-services-worker/Cargo.toml
+++ b/asset-services/asset-services-worker/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "asset-services-worker"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/asset-services/onfido/Cargo.toml
+++ b/asset-services/onfido/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "onfido"
 version = "0.1.0"
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/asset-services/rust-toolchain.toml
+++ b/asset-services/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-channel = "1.56"
+channel = "1.59"

--- a/asset-services/rust-toolchain.toml
+++ b/asset-services/rust-toolchain.toml
@@ -1,3 +1,3 @@
 # https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
 [toolchain]
-channel = "1.55"
+channel = "1.56"

--- a/asset-services/twilio-api/Cargo.toml
+++ b/asset-services/twilio-api/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Nautilus team"]
 license = "Apache-2.0"
 
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/asset-services/twilio-verify/Cargo.toml
+++ b/asset-services/twilio-verify/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Nautilus team"]
 license = "Apache-2.0"
 
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Remerging this https://github.com/ntls-io/nautilus-wallet/pull/356.
Checking for build errors first before merging.