### PR TITLE
fix(web-server): update command 'bindgen' to 'bindgen-cli'

### DIFF
--- a/web-server/Dockerfile
+++ b/web-server/Dockerfile
@@ -134,7 +134,7 @@ USER user
 RUN --mount=type=cache,sharing=locked,uid=1000,gid=1000,target=/home/user/.cargo/registry \
     --mount=type=cache,sharing=locked,uid=1000,gid=1000,target=/home/user/.cargo/git \
     . ~/.cargo/env && \
-    cargo install bindgen
+    cargo install bindgen-cli
 
 # Cargo make
 USER root

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -21,7 +21,7 @@ see [rust-sgx-sdk-dev-env] for one way to do this.
 You'll also need to install [bindgen], and its [requirements]:
 
 ```shell
-cargo install bindgen
+cargo install bindgen-cli
 sudo apt install llvm-dev libclang-dev clang
 ```
 


### PR DESCRIPTION
`bindgen` recently split out their cli-tool and the library into two parts.
This is causing our web-server tests to fail.