### PR TITLE
fix(backend-services): incorrect argument

### DIFF
--- a/backend-services/src/data_service/operations/dispatch.py
+++ b/backend-services/src/data_service/operations/dispatch.py
@@ -20,14 +20,10 @@ class MethodNotFound(Exception):
 async def dispatch(request: Action) -> Response:
     match request.method:  # noqa: E999
         case ActionMethod.CREATE_BOOKMARK:
-            return await create_bookmark(
-                CreateBookmark.parse_obj(request.params.dict())
-            )
+            return await create_bookmark(CreateBookmark.parse_obj(request.params))
         case ActionMethod.DELETE_BOOKMARK:
-            return await delete_bookmark(
-                DeleteBookmark.parse_obj(request.params.dict())
-            )
+            return await delete_bookmark(DeleteBookmark.parse_obj(request.params))
         case ActionMethod.GET_BOOKMARKS:
-            return await bookmarks(GetBookmarks.parse_obj(request.params.dict()))
+            return await bookmarks(GetBookmarks.parse_obj(request.params))
         case _:
             raise MethodNotFound

--- a/backend-services/tests/data_service/operations/test_bookmark.py
+++ b/backend-services/tests/data_service/operations/test_bookmark.py
@@ -32,7 +32,7 @@ async def test_create_bookmark_success(mocker: MockerFixture) -> None:
         bookmark=Bookmark(name="test_name", address=WalletAddress("test_address")),
     )
     assert await create_bookmark(params) == CreateBookmarkResult(success=True)
-    mock_insert_one.assert_awaited_once_with(params.dict())
+    mock_insert_one.assert_awaited_once_with(params)
 
 
 @pytest.mark.asyncio
@@ -50,7 +50,7 @@ async def test_delete_bookmark_success(mocker: MockerFixture) -> None:
         bookmark=Bookmark(name="test_name", address=WalletAddress("test_address")),
     )
     assert await delete_bookmark(params) == DeleteBookmarkResult(success=True)
-    mock_delete_one.assert_awaited_once_with(filter=params.dict())
+    mock_delete_one.assert_awaited_once_with(filter=params)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Incorrect object passed to the `pydantic` model parser in various instances