### PR TITLE
fix(web-client): remove filter of xrp in session query to show opt in

### DIFF
--- a/web-client/src/app/state/session.query.ts
+++ b/web-client/src/app/state/session.query.ts
@@ -110,27 +110,21 @@ export class SessionQuery extends Query<SessionState> {
   xrplBalances: Observable<AssetAmount[] | undefined> = this.select(
     ({ xrplBalances }) =>
       ifDefined(xrplBalances, (balances) =>
-        balances
-          .filter(
-            (balance) =>
-              (environment.hideXrpBalance && balance.currency !== 'XRP') ||
-              !environment.hideXrpBalance
-          )
-          .map(({ value, currency, issuer }): AssetAmount => {
-            const amount = defined(
-              parseNumber(value),
-              `SessionQuery.xrplBalances: bad number: ${value}`
-            );
-            return currency === 'XRP'
-              ? assetAmountXrp(amount)
-              : assetAmountXrplToken(amount, {
-                  currency,
-                  issuer: defined(
-                    issuer,
-                    `SessionQuery.xrplBalances: unexpected undefined issuer for XRPL token currency ${currency}`
-                  ),
-                });
-          })
+        balances.map(({ value, currency, issuer }): AssetAmount => {
+          const amount = defined(
+            parseNumber(value),
+            `SessionQuery.xrplBalances: bad number: ${value}`
+          );
+          return currency === 'XRP'
+            ? assetAmountXrp(amount)
+            : assetAmountXrplToken(amount, {
+                currency,
+                issuer: defined(
+                  issuer,
+                  `SessionQuery.xrplBalances: unexpected undefined issuer for XRPL token currency ${currency}`
+                ),
+              });
+        })
       )
   );
 

--- a/web-client/src/app/views/pull/pull.page.html
+++ b/web-client/src/app/views/pull/pull.page.html
@@ -19,9 +19,7 @@
                   <h2 class="!font-bold">From:</h2>
                 </ion-label>
 
-                <ng-container
-                  *ngIf="sessionQuery.xrplBalances | async as balances"
-                >
+                <ng-container *ngIf="this.balances | async as balances">
                   <ion-select
                     [value]="selectedCurrency"
                     (ionChange)="setCurrency($event)"

--- a/web-client/src/app/views/pull/pull.page.ts
+++ b/web-client/src/app/views/pull/pull.page.ts
@@ -1,7 +1,9 @@
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { LoadingController, NavController } from '@ionic/angular';
-import { firstValueFrom } from 'rxjs';
+import { firstValueFrom, map } from 'rxjs';
+import { TransactionConfirmation } from 'src/app/services/algosdk.utils';
+import { checkTxResponseSucceeded } from 'src/app/services/xrpl.utils';
 import { ConnectorQuery } from 'src/app/state/connector';
 import {
   CommissionedTxResponse,
@@ -28,15 +30,13 @@ import {
   convertFromAssetAmountXrplTokenToLedger,
   isAssetAmountXrplToken,
 } from 'src/app/utils/assets/assets.xrp.token';
+import { defined, panic } from 'src/app/utils/errors/panic';
+import { withLoadingOverlayOpts } from 'src/app/utils/loading.helpers';
+import { SwalHelper } from 'src/app/utils/notification/swal-helper';
 import { environment } from 'src/environments/environment';
 import { never } from 'src/helpers/helpers';
 import * as xrpl from 'xrpl';
 import { Payment, TxResponse } from 'xrpl';
-import { TransactionConfirmation } from '../../services/algosdk.utils';
-import { checkTxResponseSucceeded } from '../../services/xrpl.utils';
-import { defined, panic } from '../../utils/errors/panic';
-import { withLoadingOverlayOpts } from '../../utils/loading.helpers';
-import { SwalHelper } from '../../utils/notification/swal-helper';
 
 @Component({
   selector: 'app-pull',
@@ -52,6 +52,15 @@ export class PullPage implements OnInit {
 
   amount: AssetAmountXrp | AssetAmountXrplToken | undefined;
 
+  balances = environment.hideXrpBalance
+    ? this.sessionQuery.xrplBalances.pipe(
+        map((balance) =>
+          balance?.filter(
+            (currency) => currency.assetDisplay.assetSymbol !== 'XRP'
+          )
+        )
+      )
+    : this.sessionQuery.xrplBalances;
   balance: AssetAmount | undefined;
   maxAmount = 1000000000;
 


### PR DESCRIPTION
I added a filter on XRP to hide XRP in session.query for pull payments.

This caused a bug where the asset-cordion component for Opting in tokens disappeared.

I removed the filter and filtered the XRP on the pull payment page instead.