### PR TITLE
fix(web-client): show opt in message on pull page

### DIFF
--- a/web-client/src/app/views/pull/pull.page.html
+++ b/web-client/src/app/views/pull/pull.page.html
@@ -8,71 +8,95 @@
 </ion-header>
 
 <ion-content>
-  <ion-grid>
-    <ion-row>
-      <ion-col>
-        <ion-card class="ion-no-margin">
-          <ion-list lines="full" class="!p-0">
-            <ion-item-group>
-              <ion-item color="white" lines="none">
-                <ion-label>
-                  <h2 class="!font-bold">From:</h2>
-                </ion-label>
+  <div
+    *ngIf="availableAccounts === 0; else optedIn"
+    class="ion-text-center p-2"
+  >
+    <p>
+      You need to first opt into {{this.tokenSymbol}} to be able to do a pull
+      payment.
+    </p>
+  </div>
 
-                <ng-container *ngIf="this.balances | async as balances">
-                  <ion-select
-                    [value]="selectedCurrency"
-                    (ionChange)="setCurrency($event)"
-                    slot="end"
-                    *ngIf="balances.length > 1"
-                    class="font-nasalization text-primary"
-                  >
-                    <ion-select-option
-                      [value]="option.assetDisplay.assetSymbol"
-                      *ngFor="let option of balances"
-                      class="font-bold font-nasalization"
-                    >
-                      {{option | assetSymbol}}
-                    </ion-select-option>
-                  </ion-select>
-                </ng-container>
-              </ion-item>
-              <ion-item color="white">
-                <ion-icon name="wallet" color="primary" slot="start"></ion-icon>
-                <ion-label class="ion-text-wrap">
-                  <p class="font-mono font-bold">{{senderAddress}}</p>
-                </ion-label>
-              </ion-item>
-            </ion-item-group>
-            <ion-item-group *ngIf="sessionQuery.wallet | async as wallet">
-              <ion-item color="white" lines="none">
-                <ion-label>
-                  <h2 class="!font-bold">To:</h2>
-                </ion-label>
-              </ion-item>
-              <ion-item color="white" lines="none">
-                <ion-icon name="wallet" color="primary" slot="start"></ion-icon>
-                <ion-label class="ion-text-wrap">
-                  <h2 class="font-mono !font-bold">{{wallet.owner_name}}</h2>
-                  <p>{{wallet.wallet_id}}</p>
-                </ion-label>
-              </ion-item>
-            </ion-item-group>
-          </ion-list>
-        </ion-card>
-      </ion-col>
-    </ion-row>
-    <ion-row>
-      <ion-col>
-        <app-pay-amount-form
-          (amountSubmitted)="onAmountSubmitted($event)"
-          [autofocus]="true"
-          [balance]="balance"
-          [maxAmount]="maxAmount"
-        ></app-pay-amount-form>
-      </ion-col>
-    </ion-row>
-  </ion-grid>
+  <ng-template #optedIn>
+    <ion-content>
+      <ion-grid>
+        <ion-row>
+          <ion-col>
+            <ion-card class="ion-no-margin">
+              <ion-list lines="full" class="!p-0">
+                <ion-item-group>
+                  <ion-item color="white" lines="none">
+                    <ion-label>
+                      <h2 class="!font-bold">From:</h2>
+                    </ion-label>
+
+                    <ng-container *ngIf="this.balances | async as balances">
+                      <ion-select
+                        [value]="selectedCurrency"
+                        (ionChange)="setCurrency($event)"
+                        slot="end"
+                        *ngIf="balances.length > 1"
+                        class="font-nasalization text-primary"
+                      >
+                        <ion-select-option
+                          [value]="option.assetDisplay.assetSymbol"
+                          *ngFor="let option of balances"
+                          class="font-bold font-nasalization"
+                        >
+                          {{option | assetSymbol}}
+                        </ion-select-option>
+                      </ion-select>
+                    </ng-container>
+                  </ion-item>
+                  <ion-item color="white">
+                    <ion-icon
+                      name="wallet"
+                      color="primary"
+                      slot="start"
+                    ></ion-icon>
+                    <ion-label class="ion-text-wrap">
+                      <p class="font-mono font-bold">{{senderAddress}}</p>
+                    </ion-label>
+                  </ion-item>
+                </ion-item-group>
+                <ion-item-group *ngIf="sessionQuery.wallet | async as wallet">
+                  <ion-item color="white" lines="none">
+                    <ion-label>
+                      <h2 class="!font-bold">To:</h2>
+                    </ion-label>
+                  </ion-item>
+                  <ion-item color="white" lines="none">
+                    <ion-icon
+                      name="wallet"
+                      color="primary"
+                      slot="start"
+                    ></ion-icon>
+                    <ion-label class="ion-text-wrap">
+                      <h2 class="font-mono !font-bold">
+                        {{wallet.owner_name}}
+                      </h2>
+                      <p>{{wallet.wallet_id}}</p>
+                    </ion-label>
+                  </ion-item>
+                </ion-item-group>
+              </ion-list>
+            </ion-card>
+          </ion-col>
+        </ion-row>
+        <ion-row>
+          <ion-col>
+            <app-pay-amount-form
+              (amountSubmitted)="onAmountSubmitted($event)"
+              [autofocus]="true"
+              [balance]="balance"
+              [maxAmount]="maxAmount"
+            ></app-pay-amount-form>
+          </ion-col>
+        </ion-row>
+      </ion-grid>
+    </ion-content>
+  </ng-template>
 </ion-content>
 
 <ion-modal [isOpen]="isPinEntryOpen" (didDismiss)="isPinEntryOpen = false">

--- a/web-client/src/app/views/pull/pull.page.ts
+++ b/web-client/src/app/views/pull/pull.page.ts
@@ -50,6 +50,8 @@ export class PullPage implements OnInit {
     ? environment.tokenSymbol
     : 'XRP';
 
+  tokenSymbol = environment.tokenSymbol;
+  availableAccounts?: number;
   amount: AssetAmountXrp | AssetAmountXrplToken | undefined;
 
   balances = environment.hideXrpBalance
@@ -81,6 +83,9 @@ export class PullPage implements OnInit {
       // this.navCtrl.navigateRoot('wallet/transfer-funds');
       this.navCtrl.pop();
     }
+    this.balances.subscribe(
+      (balance) => (this.availableAccounts = balance?.length)
+    );
   }
 
   async getXrplBalance(currency: string): Promise<AssetAmount | undefined> {


### PR DESCRIPTION
Small bug from Pull Payments:

When `hideXrpBalance` is `true` and user has no trustline created to the tokenIssuer for the tokenSymbol, the pull page must either not show or display message like the pay page because you cannot receive FOO if you do not have trustline established.

![image](https://user-images.githubusercontent.com/31125065/206395873-ac481d39-28c0-40b4-ad5a-5aa4c3fdde1c.png)

