### PR TITLE
fix(web-client): Change auth_map type to Object type.

### DIFF
--- a/web-client/src/app/state/session.service.ts
+++ b/web-client/src/app/state/session.service.ts
@@ -58,7 +58,7 @@ export class SessionService {
         owner_name: name,
         auth_pin: pin,
         phone_number,
-        auth_map,
+        auth_map: Object.fromEntries(auth_map),
       };
       const result: CreateWalletResult = await this.enclaveService.createWallet(
         request

--- a/web-client/src/schema/actions.ts
+++ b/web-client/src/schema/actions.ts
@@ -6,7 +6,7 @@ import { Bytes, WalletId, WalletPin } from './types';
 export type CreateWallet = {
   owner_name: string;
   auth_pin: WalletPin;
-  auth_map: Map<string, string>;
+  auth_map:Object;
   phone_number?: string;
 };
 

--- a/web-client/src/schema/actions.ts
+++ b/web-client/src/schema/actions.ts
@@ -6,7 +6,7 @@ import { Bytes, WalletId, WalletPin } from './types';
 export type CreateWallet = {
   owner_name: string;
   auth_pin: WalletPin;
-  auth_map:Object;
+  auth_map: object;
   phone_number?: string;
 };
 


### PR DESCRIPTION
### Aim: Correctly save user's security answers in the enclave.

### Description

- With the current implementation, the user's answers to  security questions are not saved correctly as the JavaScript message pack library does not seem to support ES6 Maps. More details of this issue can be found on this [link](https://github.com/msgpack/msgpack-javascript/issues/138).
- To fix this issue, the auth_map's type is converted (from a Map<string, string> type) to a Object type.