### PR TITLE
fix(cors): allow `localhost:4200` on staging

### DIFF
--- a/backend-services/src/web_asgi/main.py
+++ b/backend-services/src/web_asgi/main.py
@@ -23,7 +23,7 @@ mongo_engine = AIOEngine(
 
 origins = [str(app_settings.primary_origin)]
 if app_settings.staging_mode:
-    origins.append("http://localhost:*")
+    origins.append("http://localhost:4200")
 
 
 app = FastAPI()


### PR DESCRIPTION
As requested, let the CORS policy allow connections from `localhost:4200` on our staging environment