### PR TITLE
chore(web-server): add pin reset tests

### DIFF
--- a/web-server/sgx-wallet-impl/src/wallet_operations/pin_reset.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/pin_reset.rs
@@ -88,9 +88,9 @@ pub fn reset_wallet_pin(request: &PinReset) -> PinResetResult {
             stored.auth_pin = request.new_pin.clone();
             stored
         }) {
-            Ok(Some(_)) => return PinResetResult::Reset,
+            Ok(Some(_)) => PinResetResult::Reset,
             Ok(None) => panic!("Wallet storable expected but not found"),
-            Err(err) => return PinResetResult::Failed(err.to_string()),
+            Err(err) => PinResetResult::Failed(err.to_string()),
         },
     )
 }

--- a/web-server/sgx-wallet-test/enclave/src/lib.rs
+++ b/web-server/sgx-wallet-test/enclave/src/lib.rs
@@ -51,6 +51,8 @@ pub extern "C" fn run_tests_ecall() -> usize {
         wallet_operations::test_sign_transaction::sign_transaction_works,
         wallet_operations::test_sign_transaction_msgpack::prop_transaction_msgpack_roundtrips,
         wallet_operations::test_sign_transaction_xrpl::sign_transaction_empty,
+        wallet_operations::test_pin_reset::start_pin_reset_success,
+        wallet_operations::test_pin_reset::reset_wallet_pin_success,
         wallet_operations::test_store::unlock_wallet_bad_auth_pin,
         wallet_operations::test_store::unlock_wallet_malformed_wallet_id,
         wallet_operations::test_store::unlock_wallet_not_found,

--- a/web-server/sgx-wallet-test/enclave/src/wallet_operations/mod.rs
+++ b/web-server/sgx-wallet-test/enclave/src/wallet_operations/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod test_dispatch;
 pub(crate) mod test_get_xrpl_wallet;
 pub(crate) mod test_load_onfido_check;
 pub(crate) mod test_open_wallet;
+pub(crate) mod test_pin_reset;
 pub(crate) mod test_save_onfido_check;
 pub(crate) mod test_sign_transaction;
 pub(crate) mod test_sign_transaction_msgpack;

--- a/web-server/sgx-wallet-test/enclave/src/wallet_operations/test_pin_reset.rs
+++ b/web-server/sgx-wallet-test/enclave/src/wallet_operations/test_pin_reset.rs
@@ -1,0 +1,56 @@
+use std::cell::RefCell;
+use std::string::String;
+
+use secrecy::ExposeSecret;
+use sgx_wallet_impl::crypto::common::{HmacSha256, Mac};
+use sgx_wallet_impl::crypto::key_agreement::DiffieHellman;
+use sgx_wallet_impl::crypto::sgx_get_key::SgxGetKey;
+use sgx_wallet_impl::schema::actions::{
+    PinReset,
+    PinResetResult,
+    StartPinReset,
+    StartPinResetResult,
+};
+use sgx_wallet_impl::wallet_operations::pin_reset::{reset_wallet_pin, start_pin_reset};
+use sgx_wallet_impl::wallet_operations::store::load_wallet;
+
+use crate::helpers::wallet_store::{create_test_auth_map, create_test_wallet};
+
+pub fn start_pin_reset_success() {
+    let stored_wallet = create_test_wallet();
+    let request = StartPinReset {
+        wallet_id: stored_wallet.wallet_id,
+        wallet_auth_map: RefCell::new(create_test_auth_map()),
+        client_pk: [1u8; 32],
+    };
+    let result = start_pin_reset(&request);
+    assert!(matches!(result, StartPinResetResult::ServerPk(_)))
+}
+
+pub fn reset_wallet_pin_success() {
+    let client_pk = [1u8; 32];
+    let test_wallet = create_test_wallet();
+    let stored_wallet = load_wallet(&test_wallet.wallet_id).unwrap().unwrap();
+    let new_pin = String::from("654321");
+
+    let stored = rmp_serde::to_vec(&stored_wallet).unwrap();
+    let sgx_get_key = SgxGetKey::with_salt(
+        &[stored.as_slice(), &client_pk.as_slice()].concat(),
+        stored_wallet.wallet_id.as_bytes(),
+    );
+    let shared_secret = DiffieHellman::new(
+        sgx_get_key.get_key(),
+        Some(stored_wallet.wallet_id.as_bytes()),
+    )
+    .diffie_hellman(&client_pk);
+
+    let mut mac = HmacSha256::new_from_slice(shared_secret.expose_secret()).unwrap();
+    mac.update(new_pin.as_bytes());
+    let request = PinReset {
+        client_pk,
+        new_pin,
+        new_pin_mac: <[u8; 32]>::try_from(mac.finalize().into_bytes()).unwrap(),
+        wallet_id: stored_wallet.wallet_id.clone(),
+    };
+    assert!(matches!(reset_wallet_pin(&request), PinResetResult::Reset));
+}


### PR DESCRIPTION
### Overview

These tests we accidentally left out of #494.

### Current status

Currently the test `reset_wallet_pin_success` fails due to an assertion failure at the very end.  For unknown reasons the function call to `reset_wallet_pin` returns the `InvalidAuth` variant of `PinResetResult` rather than the intended variant `PinResetResult::Reset`.

### Steps to reproduce

Assuming your environment has already been properly set up and the Docker daemon is both installed and running, the tests can be run by entering
```sh
docker compose run test-sw
```
in the `web-server` subdirectory of the repository.