### PR TITLE
ci(Dockerfile): pin `bindgen-cli` version to 0.63.0

### DIFF
--- a/web-server/Dockerfile
+++ b/web-server/Dockerfile
@@ -134,7 +134,7 @@ USER user
 RUN --mount=type=cache,sharing=locked,uid=1000,gid=1000,target=/home/user/.cargo/registry \
     --mount=type=cache,sharing=locked,uid=1000,gid=1000,target=/home/user/.cargo/git \
     . ~/.cargo/env && \
-    cargo install bindgen-cli
+    cargo install --version 0.63.0 bindgen-cli
 
 # Cargo make
 USER root


### PR DESCRIPTION
Version 0.64.0 of `bindgen-cli` is either broken at present or, at the very least, is incompatible with the rest of our build/dev setup.  This pins it to version 0.63.0 which is known to work for us.