### PR TITLE
fix(web-server): calculate public key from secret

### DIFF
--- a/web-server/sgx-wallet-impl/src/crypto/sgx_get_key.rs
+++ b/web-server/sgx-wallet-impl/src/crypto/sgx_get_key.rs
@@ -6,6 +6,7 @@ use sgx_types::{
     SGX_KEYPOLICY_MRSIGNER,
     SGX_KEYSELECT_SEAL,
 };
+use x25519_dalek::StaticSecret;
 
 use super::common::*;
 use crate::ported::crypto::sgx_get_key_helper;
@@ -47,9 +48,10 @@ impl SgxGetKey {
             |salt| HkdfSha256::new(Some(&salt), &secret_key),
         );
         hkdf_expand(&hkdf, &mut output);
+        let x25519_secret = StaticSecret::from(output);
         KeyPair {
             sk: Secret::new(output),
-            pk: x25519_dalek::PublicKey::from(output).to_bytes(),
+            pk: x25519_dalek::PublicKey::from(&x25519_secret).to_bytes(),
         }
     }
 }


### PR DESCRIPTION
The public key needs to be calculated from the corresponding secret key.  This PR has been set to draft state until the upstream CI change has been incorporated.