### PR TITLE
Fix remember address issue & a confirmation dialog box before removing a saved address 

### DIFF
--- a/web-client/src/app/components/pin-entry/pin-entry.component.ts
+++ b/web-client/src/app/components/pin-entry/pin-entry.component.ts
@@ -110,33 +110,35 @@ export class PinEntryComponent implements OnInit {
       this.walletAccessPage.address !== undefined
         ? this.walletAccessPage.address
         : '';
-    console.log(saveWalletAddress);
     try {
-      await this.notification.swal
-        .fire({
-          titleText: 'Enter Wallet Nickname.',
-          input: 'text',
-          confirmButtonText: 'Confirm',
-          showCancelButton: true,
-          showLoaderOnConfirm: true,
-          reverseButtons: true,
-        })
-        .then((result) => {
-          const preferedName = result.value;
-          this.quickAccessService.addWalletAddress(
-            saveWalletAddress,
-            preferedName
-          );
-        })
-        .then(async () => {
-          await this.notification.swal.fire({
-            icon: 'success',
-            text: 'Your Wallet Address has been saved!',
-          });
-        });
+      await this.notification.swal.fire({
+        titleText: 'Enter Wallet Nickname.',
+        input: 'text',
+        confirmButtonText: 'Confirm',
+        showCancelButton: true,
+        showLoaderOnConfirm: true,
+        confirmButtonColor: 'var(--ion-color-primary)',
+        cancelButtonColor: 'var(--ion-color-medium)',
+        reverseButtons: true,
+        preConfirm: async (preferedName) => {
+          await this.saveWalletAddress(saveWalletAddress, preferedName);
+        },
+      });
     } catch (error) {
       console.log(error);
+      this.notification.swal.fire({
+        icon: 'error',
+        text: 'An error occured whilst saving your Wallet Address. Please try again.',
+      });
     }
+  }
+
+  async saveWalletAddress(walletAddress: string, preferedName: string) {
+    this.quickAccessService.addWalletAddress(walletAddress, preferedName);
+    await this.notification.swal.fire({
+      icon: 'success',
+      text: 'Your Wallet Address has been saved!',
+    });
   }
 
   async goToReset() {

--- a/web-client/src/app/components/quick-access/quick-access.component.ts
+++ b/web-client/src/app/components/quick-access/quick-access.component.ts
@@ -7,6 +7,7 @@ import {
   QAccessService,
   QAccessStore,
 } from 'src/app/state/qAccess';
+import { SwalHelper } from 'src/app/utils/notification/swal-helper';
 import { environment } from 'src/environments/environment';
 import { showToast } from '../../utils/toast.helpers';
 
@@ -24,7 +25,8 @@ export class QuickAccessComponent implements OnInit {
     private quickAccessService: QAccessService,
     private quickAccessStore: QAccessStore,
     private toastCtrl: ToastController,
-    public quickAccessQuery: QAccessQuery
+    public quickAccessQuery: QAccessQuery,
+    private notification: SwalHelper
   ) {}
 
   async ionViewWillEnter() {
@@ -34,9 +36,22 @@ export class QuickAccessComponent implements OnInit {
   ngOnInit() {}
 
   async deleteAddress(address: QAccess) {
-    await this.quickAccessService.deleteAddress(address.walletAddress);
-    this.quickAccessStore.remove(address.id);
-    this.showSuccess('Wallet Address deleted');
+    this.notification.swal.fire({
+      icon: 'warning',
+      titleText: 'Delete Saved Wallet Address',
+      text: 'Are you sure you want to delete this Wallet Address?',
+      showCancelButton: true,
+      confirmButtonText: 'Yes',
+      showLoaderOnConfirm: true,
+      confirmButtonColor: 'var(--ion-color-primary)',
+      cancelButtonColor: 'var(--ion-color-medium)',
+      reverseButtons: true,
+      preConfirm: async () => {
+        await this.quickAccessService.deleteAddress(address.walletAddress);
+        this.quickAccessStore.remove(address.id);
+        this.showSuccess('Wallet Address deleted');
+      },
+    });
   }
 
   async showSuccess(message: string) {


### PR DESCRIPTION
### Remember Address Issue

When user clicks on ""remember address"", once pin entered, the wallet requests user to enter a nickname and press Ok. If users changes his mind and hits cancel, the wallet is still saved with nickname ""undefined"". In this case, it not only creates an Unknown item in the saved addresses list but duplicates the last entry in the existing saved addresses list where ones already exist. Lastly it allows users to save addresses they already have in their saved addresses which causes confusion and long duplicate lists in the saved addresses.

### Remove saved address needs a confirmation dialog box

Current functionality for the removal of saved addresses is to only click the red bin icon on the entry - and it is instantly removed. This can be done far too easily by mistake on a mobile phone, either as the user navigates the screen or tries to copy the saved address (as this requires pressing a button next to delete). Users will heavily depend on their wallet address being in the saved addresses and raise issues when this gets deleted. The functionality should require confirmation through a yes/no dialog box before deleting the entry.