### PR TITLE
refactor(web-client): nickname prompt before login

### DIFF
--- a/web-client/src/app/state/qAccess/q-access.service.ts
+++ b/web-client/src/app/state/qAccess/q-access.service.ts
@@ -102,36 +102,44 @@ export class QAccessService implements OnDestroy {
     });
   }
 
-  async saveQuickAccess(address: string | undefined) {
+  async saveQuickAccess(
+    address: string | undefined,
+    promptForNickname: boolean = true
+  ) {
     const saveWalletAddress: string = address !== undefined ? address : '';
     try {
-      const result = await this.notification.swal.fire({
-        titleText: 'Enter Wallet Nickname.',
-        input: 'text',
-        inputAttributes: {
-          autocapitalize: 'off',
-          autocorrect: 'off',
-        },
-        focusConfirm: false,
-        confirmButtonText: 'Save Wallet Address',
-        showCancelButton: true,
-        reverseButtons: true,
-        inputValidator: (value) => {
-          if (!value) {
-            return 'Wallet nickname cannot be empty';
-          } else {
-            return null;
-          }
-        },
-      });
-      if (result.isConfirmed) {
-        const preferedName = result.value;
-        this.addWalletAddress(saveWalletAddress, preferedName);
-        await this.notification.swal.fire({
-          icon: 'success',
-          text: 'Your Wallet Address has been saved!',
+      let preferedName = '';
+      if (promptForNickname) {
+        const result = await this.notification.swal.fire({
+          titleText: 'Enter Wallet Nickname.',
+          input: 'text',
+          inputAttributes: {
+            autocapitalize: 'off',
+            autocorrect: 'off',
+          },
+          focusConfirm: false,
+          confirmButtonText: 'Save Wallet Address',
+          showCancelButton: true,
+          reverseButtons: true,
+          inputValidator: (value) => {
+            if (!value) {
+              return 'Wallet nickname cannot be empty';
+            } else {
+              return null;
+            }
+          },
         });
+        if (result.isConfirmed) {
+          preferedName = result.value;
+        } else if (result.isDismissed) {
+          return;
+        }
       }
+      this.addWalletAddress(saveWalletAddress, preferedName);
+      await this.notification.swal.fire({
+        icon: 'success',
+        text: 'Your Wallet Address has been saved!',
+      });
     } catch (error) {
       await this.notification.swal.fire({
         icon: 'error',

--- a/web-client/src/app/views/wallet-access/wallet-access.page.ts
+++ b/web-client/src/app/views/wallet-access/wallet-access.page.ts
@@ -107,7 +107,7 @@ export class WalletAccessPage implements OnInit {
       this.quickAccessService.setRememberWalletAddress(false);
     } else {
       if (this.quickAccessService.getRememberWalletAddress()) {
-        this.quickAccessService.saveQuickAccess(this.address);
+        await this.quickAccessService.saveQuickAccess(this.address, true); // prompt user to enter a nickname
         this.quickAccessService.setRememberWalletAddress(false);
       }
       await this.navCtrl.navigateRoot(['/wallet']);


### PR DESCRIPTION
### Background

The enter Wallet Nickname dialog box appears on clicking Confirm on the PIN screen, the user then clicks on the text box and starts entering a name and as the app progresses in the background the text box loses focus so the user typing does not work. Note that this is very awkward in Palau where the lag due to internet is much longer (it all happens over many seconds as opposed to 1-2 seconds).

### Acceptance Criteria

Wait for the wallet nickname to be entered before opening the app

Prevent the same wallet from being saved twice. If the wallet address already exists in local storage do not display the save address checkbox to the user again