### PR TITLE
fix(backend-services): set correct event loop for OTP Twilio async call

### DIFF
--- a/backend-services/src/auth_service/operations/twilio_2fa.py
+++ b/backend-services/src/auth_service/operations/twilio_2fa.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from fastapi import HTTPException
 from twilio.rest import Client
 
@@ -13,9 +15,14 @@ from common.settings import AppSettings
 async def send_otp_to_user(
     settings: AppSettings, client: Client, params: SendOtp
 ) -> SendOtpResponse:
+    loop = asyncio.get_event_loop()
+    asyncio.set_event_loop(loop)  # Set the Twilio client's event loop as the default
+
     verification = await client.verify.v2.services(
         settings.twilio_service_sid
     ).verifications.create_async(to=params.phone_number, channel="sms")
+
+    asyncio.set_event_loop(None)  # Reset the default event loop
 
     if verification.sid is None:
         raise HTTPException(500)


### PR DESCRIPTION
### Problem/Bug

From staging backend-services logs container:
```
[2023-05-22 15:30:43 +0000] [11] [ERROR] Exception in ASGI application Traceback (most recent call last): File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 419, in run_asgi result = await app( # type: ignore[func-returns-value] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__ return await self.app(scope, receive, send) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/fastapi/applications.py", line 276, in __call__ await super().__call__(scope, receive, send) File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/starlette/applications.py", line 122, in __call__ await self.middleware_stack(scope, receive, send) File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/starlette/middleware/errors.py", line 184, in __call__ raise exc File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/starlette/middleware/errors.py", line 162, in __call__ await self.app(scope, receive, _send) File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/starlette/middleware/cors.py", line 91, in __call__ await self.simple_response(scope, receive, send, request_headers=headers) File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/starlette/middleware/cors.py", line 146, in simple_response await self.app(scope, receive, send) File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 79, in __call__ raise exc File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 68, in __call__ await self.app(scope, receive, sender) File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__ raise e File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__ await self.app(scope, receive, send) File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/starlette/routing.py", line 718, in __call__ await route.handle(scope, receive, send) File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/starlette/routing.py", line 276, in handle await self.app(scope, receive, send) File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/starlette/routing.py", line 66, in app response = await func(request) ^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/fastapi/routing.py", line 237, in app raw_response = await run_endpoint_function( ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/fastapi/routing.py", line 163, in run_endpoint_function return await dependant.call(**values) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/var/app/src/web_asgi/main.py", line 144, in post_send_otp_to_user return await send_otp_to_user( ^^^^^^^^^^^^^^^^^^^^^^^ File "/var/app/src/auth_service/operations/twilio_2fa.py", line 16, in send_otp_to_user verification = await client.verify.v2.services( ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/twilio/rest/verify/v2/service/verification.py", line 433, in create_async payload = await self._version.create_async( ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/twilio/base/version.py", line 481, in create_async response = await self.request_async( ^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/twilio/base/version.py", line 73, in request_async return await self.domain.request_async( ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/twilio/base/domain.py", line 84, in request_async return await self.twilio.request_async( ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/twilio/base/client_base.py", line 139, in request_async return await self.http_client.request( ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/twilio/http/async_http_client.py", line 108, in request response = await session.request(**kwargs) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/aiohttp/client.py", line 536, in _request conn = await self._connector.connect( ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/aiohttp/connector.py", line 540, in connect proto = await self._create_connection(req, traces, timeout) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/aiohttp/connector.py", line 901, in _create_connection _, proto = await self._create_direct_connection(req, traces, timeout) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/home/user/.cache/pypoetry/virtualenvs/wallet-backend-services-ydm62z-a-py3.11/lib/python3.11/site-packages/aiohttp/connector.py", line 1152, in _create_direct_connection hosts = await asyncio.shield(host_resolved) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ RuntimeError: Task cb=[set.discard()]> got Future ._outer_done_callback() at /usr/local/lib/python3.11/asyncio/tasks.py:898]> attached to a different loop
```

This error happens when testing `/otp/send-to-user` in docker on staging but this error doesn't happen when running locally.

### Testing Solution
Ensure that your application's event loop is compatible with the one used by `aiohttp`. You can do this by creating a separate event loop specifically for the Twilio client and setting it as the default event loop before making the Twilio API call

https://stackoverflow.com/questions/41584243/runtimeerror-task-attached-to-a-different-loop
https://github.com/awestlake87/pyo3-asyncio/issues/19

