### PR TITLE
fix(backend-services): allow put requests for CORS policy

### DIFF
--- a/backend-services/src/web_asgi/main.py
+++ b/backend-services/src/web_asgi/main.py
@@ -73,7 +73,7 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=origins,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "HEAD", "DELETE"],
+    allow_methods=["GET", "POST", "PUT", "HEAD", "DELETE"],
     allow_headers=["*"],
 )
 


### PR DESCRIPTION
Allow PUT requests from frontend for CORS policy.

For /otp/limit/set - https://github.com/ntls-io/nautilus-wallet/blob/ec9ebb756a826d5e2f696fb0337b9fd94c15aa40/backend-services/src/web_asgi/main.py#L123-L125