### PR TITLE
fix(backend): Update set_otp_limit_trigger() function

### DIFF
--- a/backend-services/src/data_service/operations/otp.py
+++ b/backend-services/src/data_service/operations/otp.py
@@ -15,7 +15,17 @@ async def set_otp_limit_trigger(engine: Engine, params: OtpLimitTrigger) -> None
     """
     Set a new limit for the triggering of OTPs using "upsert" semantics.
     """
-    await engine.save(params)
+    existing_trigger = await engine.find_one(
+        OtpLimitTrigger,
+        (OtpLimitTrigger.wallet_id == params.wallet_id)
+        & (OtpLimitTrigger.currency_code == params.currency_code),
+    )
+
+    if existing_trigger:
+        existing_trigger.limit = params.limit
+        await engine.save(existing_trigger)
+    else:
+        await engine.save(params)
 
 
 async def otp_limit_triggers(


### PR DESCRIPTION
Update set_otp_limit_trigger() function to first check if a limit exists for a given wallet_id and currency_code. If so, update limit. If not, create a new limit theshold.