### PR TITLE
docs(web-server): pin 'bindgen-cli' version to 0.63.0

### DIFF
--- a/web-server/README.md
+++ b/web-server/README.md
@@ -21,7 +21,7 @@ see [rust-sgx-sdk-dev-env] for one way to do this.
 You'll also need to install [bindgen], and its [requirements]:
 
 ```shell
-cargo install bindgen-cli
+cargo install --version 0.63.0 bindgen-cli
 sudo apt install llvm-dev libclang-dev clang
 ```
 


### PR DESCRIPTION
Follow up on https://github.com/ntls-io/nautilus-wallet/pull/517/files, for builds without Docker, need to update README as well.