### PR TITLE
feat(backend-services): add recurring payments implementation

### DIFF
--- a/backend-services/src/data_service/operations/recurringpayment.py
+++ b/backend-services/src/data_service/operations/recurringpayment.py
@@ -1,0 +1,117 @@
+from datetime import date
+
+from bson import ObjectId
+from fastapi import HTTPException
+
+from common.types import WalletAddress
+from data_service.schema.actions import (
+    CreateRecurringPayment,
+    DeleteRecurringPayment,
+    UpdateLastPaidDate,
+    UpdateRecurringPayment,
+)
+from data_service.schema.entities import RecurringPayment
+from data_service.schema.types import Engine
+
+
+async def recurring_payments(
+    engine: Engine, wallet_id: WalletAddress
+) -> list[RecurringPayment]:
+    """
+    Fetch a list of recurring payments for the given wallet.
+    """
+    return await engine.find(RecurringPayment, RecurringPayment.wallet_id == wallet_id)
+
+
+async def create_recurring_payment(
+    engine: Engine, params: CreateRecurringPayment
+) -> None:
+    """
+    Create a new recurring payment.
+    """
+    new_recurring_payment = RecurringPayment(
+        wallet_id=params.wallet_id,
+        wallet_public_key=params.wallet_public_key,
+        recipient=params.recipient,
+        amount=params.amount,
+        currency_code=params.currency_code,
+        payment_start_date=params.payment_start_date,
+        frequency=params.frequency,
+        payment_end_date=params.payment_end_date,
+        last_paid_date=-1,
+    )
+    await engine.save(new_recurring_payment)
+
+
+async def update_recurring_payment(
+    engine: Engine, params: UpdateRecurringPayment
+) -> None:
+    """
+    Update the details of a recurring payment.
+    """
+    id_to_update = ObjectId(params.recurring_payment_id)
+    recurring_payment = await engine.find_one(
+        RecurringPayment, RecurringPayment.id == id_to_update
+    )
+    if recurring_payment is None:
+        raise HTTPException(404)
+    recurring_payment.wallet_id = params.wallet_id
+    recurring_payment.wallet_public_key = params.wallet_public_key
+    recurring_payment.recipient = params.recipient
+    recurring_payment.amount = params.amount
+    recurring_payment.currency_code = params.currency_code
+    recurring_payment.payment_start_date = params.payment_start_date
+    recurring_payment.frequency = params.frequency
+    recurring_payment.payment_end_date = params.payment_end_date
+    await engine.save(recurring_payment)
+
+
+async def delete_recurring_payment(
+    engine: Engine, params: DeleteRecurringPayment
+) -> None:
+    """
+    Delete a specified recurring payment.
+    """
+    id_to_delete = ObjectId(params.recurring_payment_id)
+    existing_recurring_payment = await engine.find_one(
+        RecurringPayment, RecurringPayment.id == id_to_delete
+    )
+    if existing_recurring_payment is None:
+        raise HTTPException(404)
+    await engine.delete(existing_recurring_payment)
+
+
+async def check_recurring_payments(engine: Engine) -> list[RecurringPayment]:
+    """
+    Retrieve a list of payments that need to happen today.
+    """
+    today = date.today()
+    payments = await engine.find(RecurringPayment)
+    result_recurring_payments = []
+
+    for payment in payments:
+        if (
+            payment.payment_start_date <= today.toordinal() <= payment.payment_end_date
+            and (
+                payment.last_paid_date == -1
+                or (today - date.fromordinal(payment.last_paid_date)).days
+                >= payment.frequency
+            )
+        ):
+            result_recurring_payments.append(payment)
+
+    return result_recurring_payments
+
+
+async def update_last_paid_date(engine: Engine, params: UpdateLastPaidDate) -> None:
+    """
+    Update the last paid date of a recurring payment after a successful payment.
+    """
+    id_to_update = ObjectId(params.recurring_payment_id)
+    recurring_payment = await engine.find_one(
+        RecurringPayment, RecurringPayment.id == id_to_update
+    )
+    if recurring_payment is None:
+        raise HTTPException(404)
+    recurring_payment.last_paid_date = params.last_paid_date
+    await engine.save(recurring_payment)

--- a/backend-services/src/data_service/schema/actions.py
+++ b/backend-services/src/data_service/schema/actions.py
@@ -38,7 +38,7 @@ class RedeemInvite(BaseModel):
 
 class CreateOtpRecipientTrigger(BaseModel):
     """
-    OTP limit creation paramaters.
+    OTP limit creation parameters.
     """
 
     wallet_id: WalletAddress
@@ -47,7 +47,7 @@ class CreateOtpRecipientTrigger(BaseModel):
 
 class DeleteOtpLimitTrigger(BaseModel):
     """
-    OTP limit deletion paramaters.
+    OTP limit deletion parameters.
     """
 
     trigger_id: str
@@ -60,7 +60,7 @@ class DeleteOtpLimitTrigger(BaseModel):
 
 class DeleteOtpRecipientTrigger(BaseModel):
     """
-    OTP limit deletion paramaters.
+    OTP limit deletion parameters.
     """
 
     trigger_id: str
@@ -69,3 +69,61 @@ class DeleteOtpRecipientTrigger(BaseModel):
     @classmethod
     def valid_object_id_hex_representation(cls: type, v: str) -> str:
         return valid_hex_representation(cls, v)
+
+
+class CreateRecurringPayment(BaseModel):
+    """
+    Recurring payment creation parameters.
+    """
+
+    wallet_id: WalletAddress
+    wallet_public_key: str
+    recipient: WalletAddress
+    amount: float
+    currency_code: str
+    payment_start_date: int
+    frequency: int
+    payment_end_date: int
+
+
+class DeleteRecurringPayment(BaseModel):
+    """
+    Recurring payment deletion parameters.
+    """
+
+    recurring_payment_id: str
+
+    @validator("recurring_payment_id")
+    @classmethod
+    def valid_object_id_hex_representation(cls: type, v: str) -> str:
+        return valid_hex_representation(cls, v)
+
+
+class UpdateRecurringPayment(BaseModel):
+    """
+    Recurring payment update parameters.
+    """
+
+    recurring_payment_id: str
+    wallet_id: WalletAddress
+    wallet_public_key: str
+    recipient: WalletAddress
+    amount: float
+    currency_code: str
+    payment_start_date: int
+    frequency: int
+    payment_end_date: int
+
+    @validator("recurring_payment_id")
+    @classmethod
+    def valid_object_id_hex_representation(cls: type, v: str) -> str:
+        return valid_hex_representation(cls, v)
+
+
+class UpdateLastPaidDate(BaseModel):
+    """
+    Last paid date update parameters.
+    """
+
+    recurring_payment_id: str
+    last_paid_date: int

--- a/backend-services/src/data_service/schema/actions.py
+++ b/backend-services/src/data_service/schema/actions.py
@@ -85,6 +85,14 @@ class CreateRecurringPayment(BaseModel):
     frequency: int
     payment_end_date: int
 
+    @validator("payment_start_date", "payment_end_date")
+    @classmethod
+    def valid_ordinal_date(cls: type, v: int) -> int:
+        if not isinstance(v, int) or v <= 0:
+            raise ValueError("Ordinal date must be a positive integer.")
+
+        return v
+
 
 class DeleteRecurringPayment(BaseModel):
     """
@@ -114,6 +122,14 @@ class UpdateRecurringPayment(BaseModel):
     frequency: int
     payment_end_date: int
 
+    @validator("payment_start_date", "payment_end_date")
+    @classmethod
+    def valid_ordinal_date(cls: type, v: int) -> int:
+        if not isinstance(v, int) or v <= 0:
+            raise ValueError("Ordinal date must be a positive integer.")
+
+        return v
+
     @validator("recurring_payment_id")
     @classmethod
     def valid_object_id_hex_representation(cls: type, v: str) -> str:
@@ -127,3 +143,11 @@ class UpdateLastPaidDate(BaseModel):
 
     recurring_payment_id: str
     last_paid_date: int
+
+    @validator("last_paid_date")
+    @classmethod
+    def valid_ordinal_date(cls: type, v: int) -> int:
+        if not isinstance(v, int) or v <= 0:
+            raise ValueError("Ordinal date must be a positive integer.")
+
+        return v

--- a/backend-services/src/data_service/schema/entities.py
+++ b/backend-services/src/data_service/schema/entities.py
@@ -54,3 +54,19 @@ class OtpRecipientTrigger(Model):
 
     wallet_id: WalletAddress
     recipient: WalletAddress
+
+
+class RecurringPayment(Model):
+    """
+    Recurring payment details setup by sender.
+    """
+
+    wallet_id: WalletAddress
+    wallet_public_key: str
+    recipient: WalletAddress
+    amount: float
+    currency_code: str
+    payment_start_date: int
+    frequency: int
+    payment_end_date: int
+    last_paid_date: int


### PR DESCRIPTION
Initial implementation of recurring payments APIs for cosmosDB.

<meta charset="utf-8"><h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:6pt;" id="docs-internal-guid-39945dd5-7fff-b1c1-5bc4-ffd9529ca055"><span style="font-size:20pt;font-family:Arial;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Database Schema - Recurring Payment</span></h1><br /><div dir="ltr" style="margin-left:0pt;" align="left">

Field | Type
-- | --
wallet_id | string
wallet_public_key | string
recipient | string
amount | float
currency_code | string
payment_start_date | integer (UNIX epoch)
frequency | days
payment_end_date| Integer (UNIX epoch)

</div>

GET | /recurring/payments - Get Recurring Payments
POST | /recurring/payment - Post Create Recurring Payment
DELETE | /recurring/payment - Delete Recurring Payment