### PR TITLE
fix(web-client): wallet address validator for bookmark.

### DIFF
--- a/web-client/src/app/components/new-bookmark/new-bookmark.component.ts
+++ b/web-client/src/app/components/new-bookmark/new-bookmark.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { BookmarkService } from 'src/app/state/bookmark';
+import { SwalHelper } from 'src/app/utils/notification/swal-helper';
+import { addressType } from 'src/app/utils/validators';
 
 @Component({
   selector: 'app-new-bookmark',
@@ -12,7 +14,8 @@ export class NewBookmarkComponent implements OnInit {
 
   constructor(
     private bookmarkService: BookmarkService,
-    private formBuilder: FormBuilder
+    private formBuilder: FormBuilder,
+    private notification: SwalHelper
   ) {
     this.bookmarkForm = this.formBuilder.group({
       name: [
@@ -30,7 +33,7 @@ export class NewBookmarkComponent implements OnInit {
 
   async createBookmark(form: FormGroup) {
     form.markAllAsTouched();
-    if (form.valid) {
+    if (form.valid && addressType(form.value.address)) {
       const { name, address } = form.value;
       await this.bookmarkService
         .createBookmark({ name, address })
@@ -39,6 +42,8 @@ export class NewBookmarkComponent implements OnInit {
             form.reset();
           }
         });
+    } else {
+      this.notification.showInvalidAddress();
     }
   }
 }

--- a/web-client/src/app/utils/notification/swal-helper.ts
+++ b/web-client/src/app/utils/notification/swal-helper.ts
@@ -18,6 +18,14 @@ export class SwalHelper {
     allowOutsideClick: false,
   });
 
+  showInvalidAddress() {
+    this.swal.fire({
+      icon: 'warning',
+      title: 'Invalid Address',
+      text: 'Please enter a valid wallet address.',
+    });
+  }
+
   showIncorrectOTPWarning() {
     this.swal.fire({
       icon: 'warning',

--- a/web-client/src/app/utils/validators.ts
+++ b/web-client/src/app/utils/validators.ts
@@ -1,4 +1,6 @@
 import { AbstractControl, ValidatorFn } from '@angular/forms';
+import algosdk from 'algosdk';
+import * as xrpl from 'xrpl';
 
 /**
  * Safely parse untrusted user input to a `number`.
@@ -42,4 +44,30 @@ export const numericValidator: ValidatorFn = (
 /** @see numericValidator*/
 export type NumericValidationError = {
   numeric: true;
+};
+
+type AddressType = 'Algorand' | 'XRPL';
+
+const addressTypes = (address: string): AddressType[] => {
+  const coerce = (t: AddressType[]) => t;
+  return [
+    ...coerce(algosdk.isValidAddress(address) ? ['Algorand'] : []),
+    ...coerce(xrpl.isValidAddress(address) ? ['XRPL'] : []),
+  ];
+};
+
+export const addressType = (address: string): AddressType | undefined => {
+  const types = addressTypes(address);
+  switch (types.length) {
+    case 0:
+      return undefined;
+    case 1:
+      return types[0];
+    default:
+      throw Error(
+        `addressType: ${JSON.stringify(
+          types
+        )} has multiple types: ${JSON.stringify(types)}`
+      );
+  }
 };

--- a/web-client/src/app/views/triggers/triggers.page.ts
+++ b/web-client/src/app/views/triggers/triggers.page.ts
@@ -1,7 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { IonInput, LoadingController } from '@ionic/angular';
-import algosdk from 'algosdk';
 import { OtpPromptService } from 'src/app/services/otp-prompt.service';
 import { OtpLimitsQuery, OtpLimitsService } from 'src/app/state/otpLimits';
 import {
@@ -12,8 +11,8 @@ import { SessionQuery } from 'src/app/state/session.query';
 import { AssetAmount } from 'src/app/utils/assets/assets.common';
 import { withLoadingOverlayOpts } from 'src/app/utils/loading.helpers';
 import { SwalHelper } from 'src/app/utils/notification/swal-helper';
+import { addressType } from 'src/app/utils/validators';
 import { environment } from 'src/environments/environment';
-import * as xrpl from 'xrpl';
 
 @Component({
   selector: 'app-triggers',
@@ -158,11 +157,7 @@ export class TriggersPage implements OnInit {
           }
         );
       } else {
-        await this.notification.swal.fire({
-          icon: 'warning',
-          title: 'Invalid Address',
-          text: 'Please input a valid wallet address',
-        });
+        this.notification.showInvalidAddress();
       }
     }
   }
@@ -247,30 +242,4 @@ export type PaymentOption = {
 
   /** (Optional) A transaction amount limit for this option. */
   transactionLimit?: number;
-};
-
-type AddressType = 'Algorand' | 'XRPL';
-
-const addressTypes = (address: string): AddressType[] => {
-  const coerce = (t: AddressType[]) => t;
-  return [
-    ...coerce(algosdk.isValidAddress(address) ? ['Algorand'] : []),
-    ...coerce(xrpl.isValidAddress(address) ? ['XRPL'] : []),
-  ];
-};
-
-const addressType = (address: string): AddressType | undefined => {
-  const types = addressTypes(address);
-  switch (types.length) {
-    case 0:
-      return undefined;
-    case 1:
-      return types[0];
-    default:
-      throw Error(
-        `addressType: ${JSON.stringify(
-          types
-        )} has multiple types: ${JSON.stringify(types)}`
-      );
-  }
 };


### PR DESCRIPTION
The aim of this PR is to resolve the following issue: [PAY: Unsupported Address Screen](https://ntls.atlassian.net/jira/software/projects/NW/boards/1?selectedIssue=NW-205).

A wallet address is first checked for its validity before saving a new bookmark. That way, any payments made via bookmarks page will consist of valid addresses.