### PR TITLE
fix(web-server): add --locked flag to bindgen-cli install command

### DIFF
--- a/web-server/Dockerfile
+++ b/web-server/Dockerfile
@@ -134,7 +134,7 @@ USER user
 RUN --mount=type=cache,sharing=locked,uid=1000,gid=1000,target=/home/user/.cargo/registry \
     --mount=type=cache,sharing=locked,uid=1000,gid=1000,target=/home/user/.cargo/git \
     . ~/.cargo/env && \
-    cargo install --version 0.63.0 bindgen-cli
+    cargo install --version 0.63.0 bindgen-cli --locked
 
 # Cargo make
 USER root

--- a/web-server/README.md
+++ b/web-server/README.md
@@ -21,7 +21,7 @@ see [rust-sgx-sdk-dev-env] for one way to do this.
 You'll also need to install [bindgen], and its [requirements]:
 
 ```shell
-cargo install --version 0.63.0 bindgen-cli
+cargo install --version 0.63.0 bindgen-cli --locked
 sudo apt install llvm-dev libclang-dev clang
 ```
 


### PR DESCRIPTION
Github action workflows were failing due to:
```
~/workspace/nautilus-wallet/web-server/sgx-wallet fix-backend-pin-reset ❯ cargo install --version 0.63.0 bindgen-cli                                                   15:17:19
    Updating crates.io index
  Installing bindgen-cli v0.63.0
  Downloaded which v4.4.0
  Downloaded libloading v0.7.4
  Downloaded glob v0.3.1
  Downloaded log v0.4.19
  Downloaded env_logger v0.9.3
  Downloaded proc-macro2 v1.0.60
  Downloaded clang-sys v1.6.1
  Downloaded bindgen v0.63.0
  Downloaded libc v0.2.146
  Downloaded os_str_bytes v6.5.1
  Downloaded 10 crates (1.1 MB) in 0.77s
error: failed to compile `bindgen-cli v0.63.0`, intermediate artifacts can be found at `/tmp/cargo-installwYOz0D`

Caused by:
  package `log v0.4.19` cannot be built because it requires rustc 1.60.0 or newer, while the currently active rustc version is 1.58.0-nightly
```

~~My local bindgen-cli version is 0.61.0 and has been working fine.~~

Added --locked flag and it installed bindgen-cli locally fine.