### PR TITLE
feat(web-server): add sign_transaction_recurring_payment operation

### DIFF
--- a/web-server/sgx-wallet-impl/src/wallet_operations/dispatch.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/dispatch.rs
@@ -16,6 +16,7 @@ use crate::wallet_operations::load_onfido_check::load_onfido_check;
 use crate::wallet_operations::open_wallet::open_wallet;
 use crate::wallet_operations::save_onfido_check::save_onfido_check;
 use crate::wallet_operations::sign_transaction::sign_transaction;
+use crate::wallet_operations::sign_transaction_recurring_payment::sign_transaction_recurring_payment;
 
 /// Implementation for [`crate::ecalls::wallet_operation::wallet_operation`].
 ///
@@ -113,6 +114,9 @@ fn wallet_operation_impl_dispatch(wallet_request: &WalletRequest) -> WalletRespo
         WalletRequest::OpenWallet(request) => open_wallet(request).into(),
         WalletRequest::GetXrplWallet(request) => get_xrpl_wallet(request).into(),
         WalletRequest::SignTransaction(request) => sign_transaction(request).into(),
+        WalletRequest::SignTransactionRecurringPayment(request) => {
+            sign_transaction_recurring_payment(request).into()
+        }
         WalletRequest::StartPinReset(request) => start_pin_reset(request).into(),
         WalletRequest::PinReset(request) => reset_wallet_pin(request).into(),
         WalletRequest::UpdateOtpPhoneNumber(request) => update_otp_phone_number(request).into(),

--- a/web-server/sgx-wallet-impl/src/wallet_operations/mod.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/mod.rs
@@ -10,6 +10,7 @@ pub mod pin_reset;
 pub mod save_onfido_check;
 pub mod sign_transaction;
 pub mod sign_transaction_algorand;
+pub mod sign_transaction_recurring_payment;
 pub(crate) mod sign_transaction_xrpl;
 pub mod store;
 pub mod update_otp_number;

--- a/web-server/sgx-wallet-impl/src/wallet_operations/sign_transaction_recurring_payment.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/sign_transaction_recurring_payment.rs
@@ -1,0 +1,36 @@
+use std::prelude::v1::String;
+
+use crate::schema::actions::{
+    SignTransactionRecurringPayment,
+    SignTransactionRecurringPaymentResult,
+    TransactionSigned,
+    TransactionToSign,
+};
+use crate::wallet_operations::sign_transaction_xrpl::sign_xrpl;
+use crate::wallet_operations::store::load_full_xrpl_wallet;
+
+pub fn sign_transaction_recurring_payment(
+    request: &SignTransactionRecurringPayment,
+) -> SignTransactionRecurringPaymentResult {
+    let xrpl_wallet = match load_full_xrpl_wallet(&request.wallet_id) {
+        Ok(xrpl_wallet) => xrpl_wallet,
+        Err(err) => return err.into(),
+    };
+
+    let sign_result: Result<TransactionSigned, String> = match &request.transaction_to_sign {
+        TransactionToSign::XrplTransaction { transaction_bytes } => {
+            let signature_bytes = sign_xrpl(&xrpl_wallet, transaction_bytes);
+            Ok(TransactionSigned::XrplTransactionSigned {
+                signed_transaction_bytes: transaction_bytes.clone(),
+                signature_bytes,
+            })
+        }
+        _ => Err(String::from("Unsupported transaction type")),
+    };
+
+    // `Result` → `SignTransactionRecurringPaymentResult`
+    match sign_result {
+        Ok(signed) => SignTransactionRecurringPaymentResult::Signed(signed),
+        Err(message) => SignTransactionRecurringPaymentResult::Failed(message),
+    }
+}

--- a/web-server/sgx-wallet-test/enclave/src/lib.rs
+++ b/web-server/sgx-wallet-test/enclave/src/lib.rs
@@ -50,6 +50,7 @@ pub extern "C" fn run_tests_ecall() -> usize {
         wallet_operations::test_sign_transaction::sign_transaction_without_tag,
         wallet_operations::test_sign_transaction::sign_transaction_works,
         wallet_operations::test_sign_transaction_msgpack::prop_transaction_msgpack_roundtrips,
+        wallet_operations::test_sign_transaction_recurring_payment::sign_transaction_recurring_payment_empty,
         wallet_operations::test_sign_transaction_xrpl::sign_transaction_empty,
         wallet_operations::test_pin_reset::start_pin_reset_success,
         wallet_operations::test_pin_reset::start_pin_reset_failure,

--- a/web-server/sgx-wallet-test/enclave/src/wallet_operations/mod.rs
+++ b/web-server/sgx-wallet-test/enclave/src/wallet_operations/mod.rs
@@ -7,5 +7,6 @@ pub(crate) mod test_pin_reset;
 pub(crate) mod test_save_onfido_check;
 pub(crate) mod test_sign_transaction;
 pub(crate) mod test_sign_transaction_msgpack;
+pub(crate) mod test_sign_transaction_recurring_payment;
 pub(crate) mod test_sign_transaction_xrpl;
 pub(crate) mod test_store;

--- a/web-server/sgx-wallet-test/enclave/src/wallet_operations/test_sign_transaction_recurring_payment.rs
+++ b/web-server/sgx-wallet-test/enclave/src/wallet_operations/test_sign_transaction_recurring_payment.rs
@@ -1,0 +1,29 @@
+use sgx_wallet_impl::schema::actions;
+use sgx_wallet_impl::schema::actions::{TransactionSigned, TransactionToSign};
+use sgx_wallet_impl::wallet_operations::sign_transaction_recurring_payment::sign_transaction_recurring_payment;
+
+use crate::helpers::wallet_store::create_test_wallet;
+
+pub(crate) fn sign_transaction_recurring_payment_empty() {
+    let existing = &create_test_wallet();
+
+    let transaction_bytes = Default::default();
+
+    let request = &actions::SignTransactionRecurringPayment {
+        wallet_id: existing.wallet_id.clone(),
+        transaction_to_sign: TransactionToSign::XrplTransaction { transaction_bytes },
+    };
+    let signed = sign_transaction_recurring_payment(request).unwrap_signed();
+
+    match signed {
+        TransactionSigned::XrplTransactionSigned {
+            signed_transaction_bytes: _,
+            signature_bytes,
+        } => {
+            assert_eq!(signature_bytes[0], 0x30); // DER tag for SEQUENCE
+        }
+        otherwise => panic!("unexpected: {:?}", otherwise),
+    }
+
+    // TODO(Bill): Test more substantially.
+}


### PR DESCRIPTION
For Recurring Payments, need an endpoint to sign XRPL transactions for Nautilus Wallet without users pin.

NB!!
Need to revert this PR after testing.