### PR TITLE
fix(backend-services): change date values to be calculated from unix timestamps for recurring payments

### DIFF
--- a/backend-services/src/data_service/operations/recurringpayment.py
+++ b/backend-services/src/data_service/operations/recurringpayment.py
@@ -1,4 +1,4 @@
-from datetime import date
+from datetime import datetime
 
 from bson import ObjectId
 from fastapi import HTTPException
@@ -85,18 +85,14 @@ async def check_recurring_payments(engine: Engine) -> list[RecurringPayment]:
     """
     Retrieve a list of payments that need to happen today.
     """
-    today = date.today()
+    today = int(datetime.now().timestamp())
     payments = await engine.find(RecurringPayment)
     result_recurring_payments = []
 
     for payment in payments:
-        if (
-            payment.payment_start_date <= today.toordinal() <= payment.payment_end_date
-            and (
-                payment.last_paid_date == -1
-                or (today - date.fromordinal(payment.last_paid_date)).days
-                >= payment.frequency
-            )
+        if payment.payment_start_date <= today <= payment.payment_end_date and (
+            payment.last_paid_date == -1
+            or (today - payment.last_paid_date) // (24 * 60 * 60) >= payment.frequency
         ):
             result_recurring_payments.append(payment)
 

--- a/backend-services/src/data_service/schema/actions.py
+++ b/backend-services/src/data_service/schema/actions.py
@@ -87,9 +87,9 @@ class CreateRecurringPayment(BaseModel):
 
     @validator("payment_start_date", "payment_end_date")
     @classmethod
-    def valid_ordinal_date(cls: type, v: int) -> int:
+    def valid_date(cls: type, v: int) -> int:
         if not isinstance(v, int) or v <= 0:
-            raise ValueError("Ordinal date must be a positive integer.")
+            raise ValueError("Date must be a positive integer.")
 
         return v
 
@@ -124,9 +124,9 @@ class UpdateRecurringPayment(BaseModel):
 
     @validator("payment_start_date", "payment_end_date")
     @classmethod
-    def valid_ordinal_date(cls: type, v: int) -> int:
+    def valid_date(cls: type, v: int) -> int:
         if not isinstance(v, int) or v <= 0:
-            raise ValueError("Ordinal date must be a positive integer.")
+            raise ValueError("Date must be a positive integer.")
 
         return v
 
@@ -146,8 +146,8 @@ class UpdateLastPaidDate(BaseModel):
 
     @validator("last_paid_date")
     @classmethod
-    def valid_ordinal_date(cls: type, v: int) -> int:
+    def valid_date(cls: type, v: int) -> int:
         if not isinstance(v, int) or v <= 0:
-            raise ValueError("Ordinal date must be a positive integer.")
+            raise ValueError("Date must be a positive integer.")
 
         return v


### PR DESCRIPTION
date.ToOrdinal() method in Python is not compatible or very difficult to know what the implementation of the function is.

So I opted to just use int value of unix timestamps instead.