### PR TITLE
refactor(web-client): payments via bookmark.

### DIFF
--- a/web-client/src/app/components/bookmark-list/bookmark-list.component.html
+++ b/web-client/src/app/components/bookmark-list/bookmark-list.component.html
@@ -15,6 +15,9 @@
         </ion-label>
         <ion-buttons>
           <ion-button (click)="sendFund(bookmark.address)">
+            <ion-icon slot="icon-only" name="card"></ion-icon>
+          </ion-button>
+          <ion-button (click)="pullPay(bookmark.address)">
             <ion-icon slot="icon-only" name="cash"></ion-icon>
           </ion-button>
           <ion-button (click)="deleteBookmark(bookmark.id)">

--- a/web-client/src/app/components/bookmark-list/bookmark-list.component.ts
+++ b/web-client/src/app/components/bookmark-list/bookmark-list.component.ts
@@ -26,6 +26,12 @@ export class BookmarkListComponent implements OnInit {
     });
   }
 
+  pullPay(address: string) {
+    this.navCtrl.navigateForward('pull', {
+      state: { address },
+    });
+  }
+
   deleteBookmark(id: string) {
     this.notification.swal.fire({
       icon: 'warning',


### PR DESCRIPTION
This PR aims to solve the following ticket: [NW-134: As a wallet holder I want to be able to make payments directly from my Bookmarks so that I do not have to do too many steps](https://ntls.atlassian.net/jira/software/projects/NW/boards/1?selectedIssue=NW-134)

Acceptance Criteria:

- The user can see 2 options/buttons on the bookmark: Send Payment & Pull Payment

- They are taken directly to the payment page without needing to copy and paste an address