### PR TITLE
refactor(web-client): improve error messages.

### DIFF
--- a/web-client/src/app/utils/notification/swal-helper.ts
+++ b/web-client/src/app/utils/notification/swal-helper.ts
@@ -26,11 +26,52 @@ export class SwalHelper {
     });
   }
 
+  showDeletedWalletError() {
+    this.swal.fire({
+      icon: 'error',
+      title: 'Transaction Failed',
+      text: 'You cannot send funds to a wallet that has been deleted.',
+    });
+  }
+
+  showDeletedWalletErrorPull() {
+    this.swal.fire({
+      icon: 'error',
+      title: 'Transaction Failed',
+      text: 'You cannot pull funds from a wallet that has been deleted.',
+    });
+  }
+
+  showDeleteAccountError() {
+    this.swal.fire({
+      icon: 'error',
+      title: 'Transaction Failed',
+      text: 'Wallet cannot be deleted currently. Please try again later.',
+    });
+  }
+
+  showCurrencyNotOptIn() {
+    this.swal.fire({
+      icon: 'error',
+      title: 'Transaction Failed',
+      text: 'The receiver needs to opt into this currency first, before trying again.',
+    });
+  }
+
+  showCurrencyNotOptInPull() {
+    this.swal.fire({
+      icon: 'error',
+      title: 'Transaction Failed',
+      text: 'The receiver may have insufficient funds or has not opted into this currency.',
+    });
+  }
+
   showInsufficientFunds() {
+    const reserveAmount = 10;
     this.swal.fire({
       icon: 'error',
       title: 'Insufficient Funds',
-      text: 'You have insufficient funds for this transaction.',
+      text: `Your transaction exceeds the minimum reserve of ${reserveAmount} XRP. Please adjust the amount and try again.`,
     });
   }
 

--- a/web-client/src/app/views/pay/pay.page.ts
+++ b/web-client/src/app/views/pay/pay.page.ts
@@ -282,6 +282,12 @@ export class PayPage implements OnInit {
       } else if (resultCode === 'tecUNFUNDED_PAYMENT') {
         this.notification.showInsufficientFunds();
         this.navCtrl.back();
+      } else if (resultCode === 'tecPATH_DRY') {
+        this.notification.showCurrencyNotOptIn();
+        this.navCtrl.back();
+      } else if (resultCode === 'tecNO_DST_INSUF_XRP') {
+        this.notification.showDeletedWalletError();
+        this.navCtrl.back();
       } else {
         await this.notifyXrplFailure({ resultCode });
       }


### PR DESCRIPTION
# Aim of this PR 

Improve ripple-related transaction error messages for the user. This PR addresses issues: [NW-107](https://ntls.atlassian.net/jira/software/projects/NW/boards/1?selectedIssue=NW-107) &  [NW-219](https://ntls.atlassian.net/jira/software/projects/NW/boards/1?selectedIssue=NW-219)

## Various scenarios to test for in this PR:

1. Sending funds to a deleted wallet.
When user tries to send funds to a deleted wallet, a notification should popup, informing the user that they cannot send funds to a wallet that has been deleted.

2. Pulling funds from a deleted wallet.
When user attempts to pull funds wallet from a deleted wallet; a notification should let them know that they should not be able to do so.

3. Pulling funds from a wallet that has insufficient tokens or has not opted into the currency.
When user attempts to pull funds wallet from a wallet that has not opted into the token (e.g. FOO) or insufficient tokens; a notification should let them know that this is not possible.

4. Deleting a newly created wallet
When a user wants to delete a new wallet that they created, this is sometimes not possible, as the address has not been validated yet on the blockchain. Therefore, a notification should appear that tells the user to try again later.