### PR TITLE
feat(web-server): initial implementation for account lock

### DIFF
--- a/web-server/sgx-wallet-impl/src/lib.rs
+++ b/web-server/sgx-wallet-impl/src/lib.rs
@@ -3,6 +3,7 @@
 
 #[macro_use]
 extern crate sgx_tstd as std;
+extern crate alloc;
 
 pub mod crypto;
 mod ecall_helpers;

--- a/web-server/sgx-wallet-impl/src/schema/actions.rs
+++ b/web-server/sgx-wallet-impl/src/schema/actions.rs
@@ -54,6 +54,7 @@ pub struct OpenWallet {
 pub enum OpenWalletResult {
     Opened(WalletDisplay),
     InvalidAuth,
+    AccountLocked,
     Failed(String),
 }
 
@@ -63,6 +64,7 @@ impl From<UnlockWalletError> for OpenWalletResult {
         match err {
             InvalidWalletId => Self::InvalidAuth,
             InvalidAuthPin => Self::InvalidAuth,
+            AccountLocked => Self::AccountLocked,
             IoError(err) => Self::Failed(err.to_string()),
         }
     }
@@ -203,6 +205,7 @@ impl From<UnlockWalletError> for SignTransactionResult {
         match err {
             InvalidWalletId => Self::InvalidAuth,
             InvalidAuthPin => Self::InvalidAuth,
+            AccountLocked => Self::Failed("Account is locked.".to_string()),
             IoError(err) => Self::Failed(err.to_string()),
         }
     }
@@ -318,6 +321,7 @@ impl From<UnlockWalletError> for SaveOnfidoCheckResult {
             InvalidWalletId => Self::InvalidAuth,
             InvalidAuthPin => Self::InvalidAuth,
             IoError(err) => Self::from(err),
+            AccountLocked => Self::Failed("Account is locked.".to_string()),
         }
     }
 }
@@ -351,6 +355,7 @@ impl From<UnlockWalletError> for LoadOnfidoCheckResult {
             InvalidWalletId => Self::InvalidAuth,
             InvalidAuthPin => Self::InvalidAuth,
             IoError(err) => Self::from(err),
+            AccountLocked => Self::Failed("Account is locked.".to_string()),
         }
     }
 }

--- a/web-server/sgx-wallet-impl/src/schema/entities.rs
+++ b/web-server/sgx-wallet-impl/src/schema/entities.rs
@@ -94,6 +94,8 @@ pub struct WalletStorable {
     pub phone_number: Option<String>,
     pub otp_phone_number: Option<String>,
 
+    pub account_attempts: u32,
+
     pub algorand_account: AlgorandAccount,
     pub xrpl_account: XrplAccount,
 

--- a/web-server/sgx-wallet-impl/src/wallet_operations/create_wallet.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/create_wallet.rs
@@ -20,6 +20,7 @@ pub fn create_wallet(request: &CreateWallet) -> Result {
         phone_number: request.phone_number.clone(),
         otp_phone_number: request.phone_number.clone(),
 
+        account_attempts: 0,
         algorand_account: new_algorand_account,
         xrpl_account: new_xrpl_account,
 

--- a/web-server/sgx-wallet-impl/src/wallet_operations/open_wallet.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/open_wallet.rs
@@ -1,12 +1,32 @@
+use alloc::string::ToString;
+
 use crate::schema::actions::{OpenWallet, OpenWalletResult};
 use crate::schema::entities::WalletDisplay;
-use crate::wallet_operations::store::unlock_wallet;
+use crate::wallet_operations::store::{mutate_wallet, unlock_wallet, UnlockWalletError};
 
 pub fn open_wallet(request: &OpenWallet) -> OpenWalletResult {
-    let stored = match unlock_wallet(&request.wallet_id, &request.auth_pin) {
-        Ok(stored) => stored,
-        Err(err) => return err.into(),
+    match unlock_wallet(&request.wallet_id, &request.auth_pin) {
+        Ok(_) => {
+            return match mutate_wallet(&request.wallet_id, |mut stored| {
+                stored.account_attempts = 0;
+                stored
+            }) {
+                Ok(Some(stored)) => OpenWalletResult::Opened(WalletDisplay::from(stored)),
+                Ok(None) => OpenWalletResult::Failed("Not found".to_string()),
+                Err(err) => OpenWalletResult::Failed(err.to_string()),
+            }
+        }
+        Err(err) => match err {
+            UnlockWalletError::InvalidAuthPin => {
+                match mutate_wallet(&request.wallet_id, |mut stored| {
+                    stored.account_attempts = stored.account_attempts + 1;
+                    stored
+                }) {
+                    _ => {}
+                }
+                return err.into();
+            }
+            _ => return err.into(),
+        },
     };
-
-    OpenWalletResult::Opened(WalletDisplay::from(stored))
 }

--- a/web-server/sgx-wallet-impl/src/wallet_operations/pin_reset.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/pin_reset.rs
@@ -53,6 +53,7 @@ pub fn reset_wallet_pin(request: &PinReset) -> PinResetResult {
         StartPinResetResult::Success => {
             match mutate_wallet(&request.wallet_id, |mut stored| {
                 stored.auth_pin = request.new_pin.clone();
+                stored.account_attempts = 0;
                 stored
             }) {
                 Ok(Some(_)) => PinResetResult::Reset,

--- a/web-server/sgx-wallet-impl/src/wallet_operations/store.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/store.rs
@@ -55,6 +55,10 @@ pub fn unlock_wallet(wallet_id: &str, auth_pin: &str) -> Result<WalletStorable, 
     let stored: WalletStorable =
         load_wallet(wallet_id)?.ok_or(UnlockWalletError::InvalidWalletId)?;
 
+    if stored.account_attempts >= 3 {
+        return Err(UnlockWalletError::AccountLocked);
+    }
+
     match ConsttimeMemEq::consttime_memeq(stored.auth_pin.as_bytes(), auth_pin.as_bytes()) {
         true => Ok(stored),
         false => Err(UnlockWalletError::InvalidAuthPin),
@@ -96,6 +100,9 @@ pub enum UnlockWalletError {
 
     #[error("I/O error while opening wallet")]
     IoError(#[from] io::Error),
+
+    #[error("too many account attempts")]
+    AccountLocked,
 }
 
 /// [`load_xrpl_wallet`] failed.

--- a/web-server/sgx-wallet-impl/src/wallet_operations/update_otp_number.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/update_otp_number.rs
@@ -23,6 +23,9 @@ pub fn update_otp_phone_number(request: &UpdateOtpPhoneNumber) -> UpdateOtpPhone
                 ))
             }
             UnlockWalletError::IoError(err) => UpdateOtpPhoneNumberResult::Failed(err.to_string()),
+            UnlockWalletError::AccountLocked => {
+                UpdateOtpPhoneNumberResult::Failed("Account is locked".to_string())
+            }
         },
     }
 }


### PR DESCRIPTION
https://ntls.atlassian.net/browse/NW-203?atlOrigin=eyJpIjoiZDg2Y2U1YjY1N2FiNGQ1ZGFkMDYxYmYxNDFhZjMxMzUiLCJwIjoiaiJ9

New feature to lock account if there are 3 attempts to log into account with incorrect pin.

This PR is for the Nautilus Wallet backend web-server.

Implementation plan:
web-server:
* add account_attempts: u32 to WalletStorable
* when open_wallet is called, increase account_attempts  by 1 if open_wallet fails for incorrect pin
* when open_wallet succeeds, reset account_attempts to 0
* when create_wallet is called for new wallet initialize account_attempts to 0
* for existing accounts, if account_attempts is none, or not there, add it to WalletStorable when open_wallet is called
* when open_wallet is called and account_attempts is equal to 3 or greater (should not be possible), return Account Lock Error with message: “You have failed to enter the correct pin 3 times. Please reset your pin in order to access your account.“ even if the pin is correct
* when pin_reset is called and OTP is successful, set new pin and reset account_attempts to 0.