### PR TITLE
fix(web-server): change account_attempts to an Option<u32>

### DIFF
--- a/web-server/sgx-wallet-impl/src/schema/entities.rs
+++ b/web-server/sgx-wallet-impl/src/schema/entities.rs
@@ -94,7 +94,7 @@ pub struct WalletStorable {
     pub phone_number: Option<String>,
     pub otp_phone_number: Option<String>,
 
-    pub account_attempts: u32,
+    pub account_attempts: Option<u32>,
 
     pub algorand_account: AlgorandAccount,
     pub xrpl_account: XrplAccount,

--- a/web-server/sgx-wallet-impl/src/wallet_operations/create_wallet.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/create_wallet.rs
@@ -20,7 +20,7 @@ pub fn create_wallet(request: &CreateWallet) -> Result {
         phone_number: request.phone_number.clone(),
         otp_phone_number: request.phone_number.clone(),
 
-        account_attempts: 0,
+        account_attempts: Some(0),
         algorand_account: new_algorand_account,
         xrpl_account: new_xrpl_account,
 

--- a/web-server/sgx-wallet-impl/src/wallet_operations/pin_reset.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/pin_reset.rs
@@ -53,7 +53,7 @@ pub fn reset_wallet_pin(request: &PinReset) -> PinResetResult {
         StartPinResetResult::Success => {
             match mutate_wallet(&request.wallet_id, |mut stored| {
                 stored.auth_pin = request.new_pin.clone();
-                stored.account_attempts = 0;
+                stored.account_attempts = Some(0);
                 stored
             }) {
                 Ok(Some(_)) => PinResetResult::Reset,

--- a/web-server/sgx-wallet-impl/src/wallet_operations/store.rs
+++ b/web-server/sgx-wallet-impl/src/wallet_operations/store.rs
@@ -55,7 +55,7 @@ pub fn unlock_wallet(wallet_id: &str, auth_pin: &str) -> Result<WalletStorable, 
     let stored: WalletStorable =
         load_wallet(wallet_id)?.ok_or(UnlockWalletError::InvalidWalletId)?;
 
-    if stored.account_attempts >= 3 {
+    if stored.account_attempts >= Some(3) {
         return Err(UnlockWalletError::AccountLocked);
     }
 


### PR DESCRIPTION
This will change the `account_attempts` field in `WalletStorable` to be an `Option<u32>` so that if older wallets do not have the `account_attempts` field set when they were created, the code will still be fine and treat the field as `None`.