### PR TITLE
feat(web-client): add error handling for account locked

### DIFF
--- a/web-client/src/app/state/session.service.ts
+++ b/web-client/src/app/state/session.service.ts
@@ -122,6 +122,8 @@ export class SessionService {
     } else if ('Failed' in result) {
       console.error(result);
       throw new Error(result.Failed);
+    } else if ('AccountLocked' in result) {
+      return 'You have failed to enter the correct pin 3 times. Please reset your pin in order to access your account.';
     } else {
       throw never(result);
     }

--- a/web-client/src/schema/actions.ts
+++ b/web-client/src/schema/actions.ts
@@ -23,6 +23,7 @@ export type OpenWallet = {
 export type OpenWalletResult =
   | { Opened: WalletDisplay }
   | { InvalidAuth: null }
+  | { AccountLocked: null }
   | { Failed: string };
 
 export type UpdateOtpPhoneNumber = {


### PR DESCRIPTION
If the backend returns Account Locked error when unlocking a wallet, display appropriate error.

https://ntls.atlassian.net/browse/NW-203