### PR TITLE
refactor: change autofund_amount from int to float

### DIFF
--- a/backend-services/src/common/settings.py
+++ b/backend-services/src/common/settings.py
@@ -20,7 +20,7 @@ class AppSettings(BaseSettings):
     autofund_key: str
     autofund_server: HttpUrl
     autofund_sequence: int
-    autofund_amount: int
+    autofund_amount: float
 
     twilio_account_sid: str
     twilio_auth_token: str


### PR DESCRIPTION
Changing `autofund_amount` from `int` to `float`  for backend-services.